### PR TITLE
M-bounded Q-constrained simulation

### DIFF
--- a/src/QSimulation/Base.agda
+++ b/src/QSimulation/Base.agda
@@ -164,6 +164,13 @@ module QSimulationBase (A X₁ X₂ : Set) (na₁ : NA X₁ A) (na₂ : NA X₂ 
     -- (xₖ R₁RR₂ y') or (k ≡ suc n and y' ∈ F₂)
     ((xs (fromℕ< k<ssn) , y') ∈ (R₁ ∘ᵣ R ∘ᵣ R₂) ⊎  (k ≡ (suc n) × NA.accept na₂ y'))
   
+  record [_]-bounded-[_]-constrained-simulation (M : ℕ) (Q : Preorder) : Set₁ where
+    constructor aBoundedConstrainedSimulation
+    field
+      R : Pred' (X₁ × X₂)
+      final : ∀ x y → R (x , y) → Final[ M ][ Q ] R x y
+      step : ∀ x y → R (x , y) → Step[ M ][ Q ] R x y
+  
   record [_]-constrained-simulation (Q : Preorder) : Set₁ where
     constructor aConstrainedSimulation
     field

--- a/src/QSimulation/Bounded.agda
+++ b/src/QSimulation/Bounded.agda
@@ -31,7 +31,13 @@ open import QSimulation.Base
 open QSimulation.Base.ConditionOnQ A
 open QSimulation.Base.QSimulationBase A X₁ X₂ na₁ na₂
 open import QSimulation.Lemma
-    using (inject≤inject₁≡inject₁inject≤; inject≤[fromℕ<[a≤b]][b≤c]≡fromℕ<[a≤c]; casti≡i; cast-sucF; +F-sucF; cast-cast; inject≤[fromℕ[a]][a<b]≡cast[fromℕ[a]+F0])
+    using
+      ( inject≤inject₁≡inject₁inject≤
+      ; inject≤[fromℕ<[a≤b]][b≤c]≡fromℕ<[a≤c]
+      ; casti≡i; cast-sucF; +F-sucF; cast-cast
+      ; [inject+]≡[+F]
+      ; fromℕ-+F-+
+      ; inject≤[fromℕ[a]][a<b]≡cast[fromℕ[a]+F0])
 
 M≤N⇒FinalN⇒FinalM :
     ∀ {M N : ℕ} → M ≤ N
@@ -224,76 +230,64 @@ module Lemma
                 suc (M + l)
                 ∎
 
-            
-            lem : ∀ {i : Fin (suc l)} →
-                xs₂ i ≡ xs (cast toℕfromℕM+sl≡s[M+l] (fromℕ M +F i))
-            lem {zeroF} = begin
-                xs₂ zeroF
-                ≡⟨⟩
-                xs₁ (fromℕ M)
-                ≡⟨ xs₁i≡xs[inject≤[i][sM≤sN]] (fromℕ M) ⟩
-                xs (inject≤ (fromℕ M) sM≤sn)
-                ≡⟨ ≡cong xs (inject≤[fromℕ[a]][a<b]≡cast[fromℕ[a]+F0] sM≤sn toℕfromℕM+sl≡s[M+l]) ⟩
-                xs (cast toℕfromℕM+sl≡s[M+l] (fromℕ M +F zeroF))
-                ∎
-            lem {sucF i} = begin
-                xs₂ (sucF i)
-                ≡⟨⟩
-                xs₂^ i
-                ≡⟨ xs₂^i≡xs[sucF[cast[inject+'[M][i]]]] i ⟩
-                xs (sucF (cast ≡refl (inject+' M i)))
-                ≡⟨ ≡cong (λ j → xs (sucF j)) (casti≡i {M + l} {≡refl} (inject+' M i)) ⟩
-                xs (sucF (inject+' M i))
-                ≡⟨ ≡cong xs
-                    (begin
-                    sucF (inject+' M i)
-                    ≡⟨ ≡cong sucF {!   !} ⟩
-                    sucF (cast (≡cong (λ a → (a + l)) (toℕ-fromℕ M)) (fromℕ M +F i))
-                    ≡⟨ ≡sym (cast-sucF {toℕ (fromℕ M) + l} {M + l} {(≡cong (λ a → (a + l)) (toℕ-fromℕ M))} {_} (fromℕ M +F i)) ⟩
-                    cast (≡cong (λ a → suc (a + l)) (toℕ-fromℕ M)) (sucF (fromℕ M +F i))
-                    ≡⟨ ≡sym (cast-cast (≡sym (+-suc (toℕ (fromℕ M)) l)) toℕfromℕM+sl≡s[M+l] (≡cong (λ a → suc (a + l)) (toℕ-fromℕ M)) (sucF (fromℕ M +F i))) ⟩
-                    cast toℕfromℕM+sl≡s[M+l] (cast (≡sym (+-suc (toℕ (fromℕ M)) l)) (sucF (fromℕ M +F i)))
-                    ≡⟨ ≡cong (λ i → cast toℕfromℕM+sl≡s[M+l] i) (≡sym (+F-sucF (fromℕ M) i)) ⟩
-                    cast toℕfromℕM+sl≡s[M+l] (fromℕ M +F sucF i)
-                    ∎)
-                ⟩
-                xs (cast toℕfromℕM+sl≡s[M+l] (fromℕ M +F sucF i))
-                ∎
-
             last[xs₂]≡last[xs] : lastF xs₂ ≡ lastF xs
             last[xs₂]≡last[xs] = begin
                 xs₂ (fromℕ l)
                 ≡⟨ lem {fromℕ l} ⟩
-                xs (cast _ (fromℕ M +F (fromℕ l)))
-                ≡⟨ ≡cong xs {!   !} ⟩
+                xs (cast p (fromℕ M +F (fromℕ l)))
+                ≡⟨ ≡cong xs (fromℕ-+F-+ M l {p}) ⟩
                 xs (fromℕ (M + l))
                 ∎
-            {-
                 where
-                    lem : ∀ {i : Fin (suc l)} →
-                        xs₂ i ≡ xs (cast {!   !} (fromℕ M +F i))
-                    lem {zeroF} = begin
-                        xs₂ zeroF
-                        ≡⟨⟩
-                        xs₁ (fromℕ M)
-                        ≡⟨ xs₁i≡xs[inject≤[i][sM≤sN]] (fromℕ M) ⟩
-                        xs (inject≤ (fromℕ M) sM≤sn)
-                        ≡⟨ {!   !} ⟩
-                        {!   !}
-                        ∎
-                    lem {sucF i} = begin
-                        xs₂ (sucF i)
-                        ≡⟨⟩
-                        xs₂^ i
-                        ≡⟨ xs₂^i≡xs[sucF[cast[inject+'[M][i]]]] i ⟩
-                        xs (sucF (cast ≡refl (inject+' M i)))
-                        ≡⟨ ≡cong (λ j → xs (sucF j)) (casti≡i {M + l} {≡refl} (inject+' M i)) ⟩
-                        xs (sucF (inject+' M i))
-                        ≡⟨ {!   !} ⟩
-                        {!   !}
-                        ∎
-            -}
-        
+                  p : toℕ (fromℕ M) + suc l ≡ suc (M + l)
+                  p =
+                    begin
+                    toℕ (fromℕ M) + suc l
+                    ≡⟨ ≡cong (λ a → a + suc l) (toℕ-fromℕ M) ⟩
+                    M + suc l
+                    ≡⟨ +-suc M l ⟩
+                    suc (M + l)
+                    ∎
+
+                  q : (i : Fin l) → sucF (inject+' M i) ≡ cast p (fromℕ M +F sucF i)
+                  q i =
+                    begin
+                    sucF (inject+' M i)
+                    ≡⟨ ≡cong sucF (≡sym (casti≡i {M + l} {≡refl} (inject+' M i))) ⟩
+                    sucF (cast ≡refl (inject+' M i))
+                    ≡⟨ ≡cong sucF ([inject+]≡[+F] i ≡refl (≡cong (λ a → (a + l)) (toℕ-fromℕ M)) ) ⟩
+                    sucF (cast (≡cong (λ a → (a + l)) (toℕ-fromℕ M)) (fromℕ M +F i))
+                    ≡⟨ ≡sym (cast-sucF {toℕ (fromℕ M) + l} {M + l} {(≡cong (λ a → (a + l)) (toℕ-fromℕ M))} {_} (fromℕ M +F i)) ⟩
+                    cast (≡cong (λ a → suc (a + l)) (toℕ-fromℕ M)) (sucF (fromℕ M +F i))
+                    ≡⟨ ≡sym (cast-cast (≡sym (+-suc (toℕ (fromℕ M)) l)) p (≡cong (λ a → suc (a + l)) (toℕ-fromℕ M)) (sucF (fromℕ M +F i))) ⟩
+                    cast p (cast (≡sym (+-suc (toℕ (fromℕ M)) l)) (sucF (fromℕ M +F i)))
+                    ≡⟨ ≡cong (λ i → cast p i) (≡sym (+F-sucF (fromℕ M) i)) ⟩
+                    cast p (fromℕ M +F sucF i)
+                    ∎
+
+                  lem : ∀ {i : Fin (suc l)} →
+                      xs₂ i ≡ xs (cast toℕfromℕM+sl≡s[M+l] (fromℕ M +F i))
+                  lem {zeroF} = begin
+                      xs₂ zeroF
+                      ≡⟨⟩
+                      xs₁ (fromℕ M)
+                      ≡⟨ xs₁i≡xs[inject≤[i][sM≤sN]] (fromℕ M) ⟩
+                      xs (inject≤ (fromℕ M) sM≤sn)
+                      ≡⟨ ≡cong xs (inject≤[fromℕ[a]][a<b]≡cast[fromℕ[a]+F0] sM≤sn toℕfromℕM+sl≡s[M+l]) ⟩
+                      xs (cast toℕfromℕM+sl≡s[M+l] (fromℕ M +F zeroF))
+                      ∎
+                  lem {sucF i} = begin
+                      xs₂ (sucF i)
+                      ≡⟨⟩
+                      xs₂^ i
+                      ≡⟨ xs₂^i≡xs[sucF[cast[inject+'[M][i]]]] i ⟩
+                      xs (sucF (cast ≡refl (inject+' M i)))
+                      ≡⟨ ≡cong (λ j → xs (sucF j)) (casti≡i {M + l} {≡refl} (inject+' M i)) ⟩
+                      xs (sucF (inject+' M i))
+                      ≡⟨ ≡cong xs (q i) ⟩
+                      xs (cast p (fromℕ M +F sucF i))
+                      ∎
+
             last[xs₂]∈F₁ : NA.accept na₁ (lastF xs₂)
             last[xs₂]∈F₁ = step-∋ (NA.accept na₁) last[xs]∈F₁ (≡sym last[xs₂]≡last[xs])
 

--- a/src/QSimulation/Bounded.agda
+++ b/src/QSimulation/Bounded.agda
@@ -26,7 +26,8 @@ open import NA
 open import QSimulation.Base
 open QSimulation.Base.ConditionOnQ A
 open QSimulation.Base.QSimulationBase A X₁ X₂ na₁ na₂
-open import QSimulation.Lemma using (inject≤inject₁≡inject₁inject≤)
+open import QSimulation.Lemma
+    using (inject≤inject₁≡inject₁inject≤; inject≤[inject≤[i][k≤m]][m≤n]≡inject≤[i][k≤n]; inject≤[fromℕ<[a≤b]][b≤c]≡fromℕ<[a≤c])
 
 M≤N⇒FinalN⇒FinalM :
     ∀ {M N : ℕ} → M ≤ N
@@ -53,9 +54,8 @@ M≤N⇒StepM⇒StepN {M} {N} M≤N Q R .(xs zeroF) y StepM xs w ≡refl tr
 M≤N⇒StepM⇒StepN {M} {N} M≤N Q@(aPreorder ∣Q∣ _ _) R .(xs zeroF) y StepM xs w ≡refl tr
     | w↾<M , w↾≥M | w↾<Mi≡wi
     | xs↾≤M , xs↾>M | xs↾≤Mi≡xsi =
-    (k , k≢0 , sk≤sN , w' , y' , [w↾sk≤sN,w']∈Q , y⇝[w']y' , {!  !} )
+    (k , k≢0 , sk≤sN , w' , y' , [w↾sk≤sN,w']∈Q , y⇝[w']y' , [xs[fromℕ<[sk≤sN]],y']∈R )
     where
-        -- xs↾≤Mi≡xsi : (i : Fin (suc M)) → xs≤M i ≡ xs (inject≤ i (s≤s M≤N))
         xs0≡xs↾≤M0 : (xs zeroF) ≡ (xs↾≤M zeroF)
         xs0≡xs↾≤M0 = begin xs zeroF ≡⟨ ≡sym (xs↾≤Mi≡xsi zeroF) ⟩ xs↾≤M zeroF ∎
 
@@ -101,22 +101,28 @@ M≤N⇒StepM⇒StepN {M} {N} M≤N Q@(aPreorder ∣Q∣ _ _) R .(xs zeroF) y St
         [w↾<M↾≤k,w']∈Q = proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ stepM)))))
         
 
-        a : {n m k : ℕ} → (m≤n : m ≤ n) → (sk≤sm : suc k ≤ suc m)
-            → (sk≤sn : suc k ≤ suc n)
-            → (u' : Fin m → A) → (u : Fin n → A)
-            → ((i : Fin m) → u' i ≡ u (inject≤ i m≤n))
-            → (i : Fin k)
-            → (u' ↾ sk≤sm) i ≡ (u ↾ sk≤sn) i
-        a {n} {m} {k} m≤n sk≤sm sk≤sn u' u p i = {!   !}
-
-
         w↾<M↾≤k[i]≡w↾≤sN↾<k[i] : (i : Fin k) → (w↾<M ↾ sk≤sM) i ≡ (w ↾ sk≤sN) i
-        w↾<M↾≤k[i]≡w↾≤sN↾<k[i] i = begin
-            (w↾<M ↾ sk≤sM) i
-            ≡⟨ {!   !} ⟩
-            (w ↾ sk≤sN) i
-            ∎
-        -- (i : Fin M) → w i ≡ w' (inject≤ i M≤N)
+        w↾<M↾≤k[i]≡w↾≤sN↾<k[i] i = lemma M≤N sk≤sM sk≤sN w↾<M w w↾<Mi≡wi i
+            where
+                lemma : {n m k : ℕ} → (m≤n : m ≤ n) → (sk≤sm : suc k ≤ suc m)
+                    → (sk≤sn : suc k ≤ suc n)
+                    → (u' : Fin m → A) → (u : Fin n → A)
+                    → ((i : Fin m) → u' i ≡ u (inject≤ i m≤n))
+                    → (i : Fin k)
+                    → (u' ↾ sk≤sm) i ≡ (u ↾ sk≤sn) i
+                lemma {n} {m} {suc k} m≤n sk≤sm@(s≤s k≤m) sk≤sn@(s≤s k≤n) u' u p i with u' ↾ sk≤sm |  w₁i≡wi u' k≤m | u ↾ sk≤sn | w₁i≡wi u k≤n
+                lemma {n} {m} {suc k} m≤n sk≤sm@(s≤s k≤m) sk≤sn@(s≤s k≤n) u' u p i | LHS | qₗ | RHS | qᵣ =
+                    begin
+                    LHS i
+                    ≡⟨ qₗ i ⟩
+                    u' (inject≤ i k≤m)
+                    ≡⟨ p (inject≤ i k≤m) ⟩
+                    u (inject≤ (inject≤ i k≤m) m≤n)
+                    ≡⟨ ≡cong u (inject≤[inject≤[i][k≤m]][m≤n]≡inject≤[i][k≤n] i k≤m m≤n k≤n) ⟩
+                    u (inject≤ i k≤n)
+                    ≡⟨ ≡sym (qᵣ i) ⟩
+                    RHS i
+                    ∎
 
         [w↾sk≤sN,w']∈Q : (( k , w ↾ sk≤sN ) , w') ∈ ∣Q∣
         [w↾sk≤sN,w']∈Q = step-∋ ∣Q∣ [w↾<M↾≤k,w']∈Q
@@ -128,3 +134,15 @@ M≤N⇒StepM⇒StepN {M} {N} M≤N Q@(aPreorder ∣Q∣ _ _) R .(xs zeroF) y St
 
         y⇝[w']y' = proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ stepM))))))
 
+        [xs↾≤M[fromℕ<[sk≤sM]],y']∈R : (xs↾≤M (fromℕ< sk≤sM) , y') ∈ R
+        [xs↾≤M[fromℕ<[sk≤sM]],y']∈R = proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ stepM))))))
+        [xs[fromℕ<[sk≤sN]],y']∈R : (xs (fromℕ< sk≤sN) , y') ∈ R
+        [xs[fromℕ<[sk≤sN]],y']∈R = step-∋ R [xs↾≤M[fromℕ<[sk≤sM]],y']∈R
+            (≡cong (λ x → (x , y'))
+                (begin
+                xs↾≤M (fromℕ< sk≤sM)
+                ≡⟨ xs↾≤Mi≡xsi (fromℕ< sk≤sM) ⟩
+                xs (inject≤ (fromℕ< sk≤sM) (s≤s M≤N))
+                ≡⟨ ≡cong xs (inject≤[fromℕ<[a≤b]][b≤c]≡fromℕ<[a≤c] sk≤sM (s≤s M≤N) sk≤sN) ⟩
+                xs (fromℕ< sk≤sN)
+                ∎))

--- a/src/QSimulation/Bounded.agda
+++ b/src/QSimulation/Bounded.agda
@@ -7,7 +7,7 @@ module QSimulation.Bounded
 
 open import Data.Nat
 open import Data.Nat.Properties
-    using (≤-trans; m≤n+m; +-suc)
+    using (≤-trans; m≤n+m; m≤m+n; +-suc; <⇒≤)
 open import Data.Nat.Induction
     using (<-rec)
 open import Data.Fin
@@ -34,10 +34,16 @@ open import QSimulation.Lemma
     using
       ( inject≤inject₁≡inject₁inject≤
       ; inject≤[fromℕ<[a≤b]][b≤c]≡fromℕ<[a≤c]
+      ; s≤s-≤
       ; casti≡i; cast-sucF; +F-sucF; cast-cast
       ; [inject+]≡[+F]
-      ; fromℕ-+F-+
-      ; inject≤[fromℕ[a]][a<b]≡cast[fromℕ[a]+F0])
+      ; cast-fromℕ-+F-inject₁
+      ; fromℕ-+F-+-cast; cast-fromℕ
+      ; inject≤[fromℕ<[sa≤b][b≤c]]≡inject≤[fromℕ[a]][sa≤c]
+      ; cast-inject+'-cast-fromℕ
+      ; inject≤[fromℕ[a]][a<b]≡cast[fromℕ[a]+F0]
+      ; s[cast[fromℕ[a]+Fiᵇ]]≡cast[fromℕ[a]+Fsiᵇ]
+      )
 
 M≤N⇒FinalN⇒FinalM :
     ∀ {M N : ℕ} → M ≤ N
@@ -173,15 +179,6 @@ module Lemma
     k≤n⊎n<k (suc k) (suc n) | inj₁ k≤n = inj₁ (s≤s k≤n)
     k≤n⊎n<k (suc k) (suc n) | inj₂ n<k = inj₂ (s≤s n<k)
 
-    c : {X : Set}
-      → (n : ℕ)
-      → (w : FinWord n X)
-      → (p : ℕ) → (q : ℕ)
-      → (p≤q : p ≤ q) → (q≤n : q ≤ n) → (p≤n : p ≤ n)
-      → ∀ (i : Fin p)
-      → ((proj₁ (split w q≤n)) ↾ (s≤s p≤q)) i ≡ (proj₁ (split w p≤n)) i
-    c = {!!}
-
     lemma :
         (n : ℕ)
         → ( -- Induction hypothesis
@@ -207,60 +204,59 @@ module Lemma
         → ∃[ w' ] -- w' : FINWord A
         ∃[ y' ] -- y' : X₂
         (inj n w , w') ∈ ∣Q∣ × (w' ∈ FINWord-from[ y ]to[ y' ] na₂) × (y' ∈ NA.accept na₂)
-    lemma n _ x y [x,y]∈R xs w ≡refl tr last[xs]∈F₁ n<N
+    lemma n _ x y [x,y]∈R xs w ≡refl tr-xs-w last[xs]∈F₁ n<N
         -- case analysis
         with k≤n⊎n<k (suc n) M
-    lemma n _ x y [x,y]∈R xs w ≡refl tr last[xs]∈F₁ n<N
+    lemma n _ x y [x,y]∈R xs w ≡refl tr-xs-w last[xs]∈F₁ n<N
         -- base case
         | inj₁ sn≤M =
-            FinalM x y [x,y]∈R n xs w ≡refl tr last[xs]∈F₁ sn≤M
-    lemma n rec x y [x,y]∈R xs w ≡refl tr last[xs]∈F₁ n<N
+            FinalM x y [x,y]∈R n xs w ≡refl tr-xs-w last[xs]∈F₁ sn≤M
+    lemma n rec x y [x,y]∈R xs w ≡refl tr-xs-w last[xs]∈F₁ n<N
         -- step case
         | inj₂ sM≤sn@(s≤s M≤n)
         -- split `xs` at `suc M`
         with n-k M≤n | split xs sM≤sn | w₁i≡wi xs sM≤sn | w₂i≡w[k+i] {X₁} {_} {suc M} xs sM≤sn
         -- split `w` at `M`
         | split w M≤n | w₁i≡wi w M≤n | w₂i≡w[k+i] {A} {_} {M} w M≤n
-    lemma .(M + l) IH x y [x,y]∈R xs w ≡refl tr last[xs]∈F₁ n<N
+    lemma .(M + l) IH x y [x,y]∈R xs w ≡refl tr-xs-w last[xs]∈F₁ n<N
         | inj₂ sM≤sn@(s≤s M≤n)
         | l , ≡refl
-        | xs₁ , xs₂^ | xs₁i≡xs[inject≤[i][sM≤sN]] | xs₂^i≡xs[sucF[cast[inject+'[M][i]]]]
-        | w₁ , w₂ | w₁i≡w[inject≤[i][M≤N]] | w₂i≡w[sucF[cast[inject+'[M][i]]]] =
-        {!!}
+        | xs₁ , xs₂^ | xs₁i≡xs[inject≤[i][sM≤sn]] | xs₂^i≡xs[sucF[cast[inject+'[M][i]]]]
+        | w₁ , w₂ | w₁i≡w[inject≤[i][M≤n]] | w₂i≡w[sucF[cast[inject+'[M][i]]]] = construction
+        -- ({!!} , y'' , {!   !} , ({!   !}  , {!   !} , {!   !} , {!   !}) ,  y''∈F₂)
         where
             [xs₁0,y]∈R : (xs₁ zeroF , y) ∈ R
             [xs₁0,y]∈R = step-∋ R [x,y]∈R (≡cong (λ a → (a , y)) (≡sym xs₁0≡xs0))
-              where
-                xs₁0≡xs0 : xs₁ zeroF ≡ xs zeroF
-                xs₁0≡xs0 =
-                  begin
-                  xs₁ zeroF
-                  ≡⟨ xs₁i≡xs[inject≤[i][sM≤sN]] zeroF ⟩
-                  xs zeroF
-                  ∎
+                where
+                    xs₁0≡xs0 : xs₁ zeroF ≡ xs zeroF
+                    xs₁0≡xs0 =
+                        begin
+                        xs₁ zeroF
+                        ≡⟨ xs₁i≡xs[inject≤[i][sM≤sn]] zeroF ⟩
+                        xs zeroF
+                        ∎
 
-            tr₁ : (i : Fin M)
-              → (xs₁ (inject₁ i) , w₁ i , xs₁ (sucF i)) ∈ NA.trans na₁
-            tr₁ i = step-∋ (NA.trans na₁) (tr (inject≤ i M≤n))
-              (begin
-              xs (inject₁ (inject≤ i M≤n)) , w (inject≤ i M≤n) , xs (sucF (inject≤ i M≤n))
-              ≡⟨ ≡cong (λ a → (a , _ , _)) (≡sym p) ⟩
-              xs₁ (inject₁ i) , w (inject≤ i M≤n) , xs (sucF (inject≤ i M≤n))
-              ≡⟨ ≡cong (λ a → (_ , _ , a)) (≡sym (xs₁i≡xs[inject≤[i][sM≤sN]] (sucF i))) ⟩
-              xs₁ (inject₁ i) , w (inject≤ i M≤n) , xs₁ (sucF i)
-              ≡⟨ ≡cong (λ a → (_ , a , _)) (≡sym (w₁i≡w[inject≤[i][M≤N]] i)) ⟩
-              xs₁ (inject₁ i) , w₁ i , xs₁ (sucF i)
-              ∎)
-              where
-                p : xs₁ (inject₁ i) ≡ xs (inject₁ (inject≤ i M≤n))
-                p =
-                  begin
-                  xs₁ (inject₁ i)
-                  ≡⟨ xs₁i≡xs[inject≤[i][sM≤sN]] (inject₁ i) ⟩
-                  xs (inject≤ (inject₁ i) (s≤s M≤n))
-                  ≡⟨ ≡cong xs (inject≤inject₁≡inject₁inject≤ M≤n) ⟩
-                  xs (inject₁ (inject≤ i M≤n))
-                  ∎
+            tr₁ : (i : Fin M) → (xs₁ (inject₁ i) , w₁ i , xs₁ (sucF i)) ∈ NA.trans na₁
+            tr₁ i = step-∋ (NA.trans na₁) (tr-xs-w (inject≤ i M≤n))
+                (begin
+                xs (inject₁ (inject≤ i M≤n)) , w (inject≤ i M≤n) , xs (sucF (inject≤ i M≤n))
+                ≡⟨ ≡cong (λ a → (a , _ , _)) (≡sym p) ⟩
+                xs₁ (inject₁ i) , w (inject≤ i M≤n) , xs (sucF (inject≤ i M≤n))
+                ≡⟨ ≡cong (λ a → (_ , _ , a)) (≡sym (xs₁i≡xs[inject≤[i][sM≤sn]] (sucF i))) ⟩
+                xs₁ (inject₁ i) , w (inject≤ i M≤n) , xs₁ (sucF i)
+                ≡⟨ ≡cong (λ a → (_ , a , _)) (≡sym (w₁i≡w[inject≤[i][M≤n]] i)) ⟩
+                xs₁ (inject₁ i) , w₁ i , xs₁ (sucF i)
+                ∎)
+                where
+                    p : xs₁ (inject₁ i) ≡ xs (inject₁ (inject≤ i M≤n))  
+                    p =  
+                        begin
+                        xs₁ (inject₁ i)
+                        ≡⟨ xs₁i≡xs[inject≤[i][sM≤sn]] (inject₁ i) ⟩
+                        xs (inject≤ (inject₁ i) (s≤s M≤n))
+                        ≡⟨ ≡cong xs (inject≤inject₁≡inject₁inject≤ M≤n) ⟩
+                        xs (inject₁ (inject≤ i M≤n))
+                        ∎
 
             stepM = StepM (xs₁ zeroF) y  [xs₁0,y]∈R xs₁ w₁ ≡refl tr₁
 
@@ -282,121 +278,268 @@ module Lemma
             k₁≤n : k₁ ≤ M + l
             k₁≤n = ≤-pred sk₁≤sn
 
-            w' : FINWord A
-            w' = proj₁ (proj₂ (proj₂ (proj₂ stepM)))
+            v₁ : FINWord A
+            v₁ = proj₁ (proj₂ (proj₂ (proj₂ stepM)))
 
             y' : X₂
             y' = proj₁ (proj₂ (proj₂ (proj₂ (proj₂ stepM))))
 
-            [w₁↾≤k₁,w']∈Q : ((k₁ , (w₁ ↾ sk₁≤sM)) , w') ∈ ∣Q∣
-            [w₁↾≤k₁,w']∈Q = proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ stepM)))))
+            [w₁↾≤k₁,v₁]∈Q : ((k₁ , (w₁ ↾ sk₁≤sM)) , v₁) ∈ ∣Q∣
+            [w₁↾≤k₁,v₁]∈Q = proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ stepM)))))
 
-            y⇝[w']y' = proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ stepM))))))
+            y⇝[v₁]y' = proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ stepM))))))
 
             [xs₁[fromℕ<[sk₁≤sM]],y']∈R : (xs₁ (fromℕ< sk₁≤sM) , y') ∈ R
             [xs₁[fromℕ<[sk₁≤sM]],y']∈R =
               proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ stepM))))))
 
+            u₁ : FinWord k₁ A
+            u₁ = proj₁ (split w k₁≤n)
+
+            k₂ : ℕ
+            k₂ = proj₁ (n-k k₁≤n)
+            k₁+k₂≡n : k₁ + k₂ ≡ M + l
+            k₁+k₂≡n = proj₂ (n-k k₁≤n)
+
+            u₂ : FinWord k₂ A
+            u₂ = proj₂ (split w k₁≤n)
+
+            zs₂^ : FinWord k₂ X₁
+            zs₂^ = proj₂ (split xs (s≤s k₁≤n))
+
+            zs₂ : FinWord (suc k₂) X₁
+            zs₂ zeroF = xs₁ (fromℕ< sk₁≤sM)
+            zs₂ (sucF i) = zs₂^ i
+
             {-
-            xs₂ : FinWord (suc l) X₁
-            xs₂ = (xs₁ (fromℕ M)) ∷ᶠ xs₂^
-
-            last[xs₂]≡last[xs] : lastF xs₂ ≡ lastF xs
-            last[xs₂]≡last[xs] = begin
-                xs₂ (fromℕ l)
-                ≡⟨ lem {fromℕ l} ⟩
-                xs (cast p (fromℕ M +F (fromℕ l)))
-                ≡⟨ ≡cong xs (fromℕ-+F-+ M l {p}) ⟩
-                xs (fromℕ (M + l))
-                ∎
-                where
-                  p : toℕ (fromℕ M) + suc l ≡ suc (M + l)
-                  p =
-                    begin
-                    toℕ (fromℕ M) + suc l
-                    ≡⟨ ≡cong (λ a → a + suc l) (toℕ-fromℕ M) ⟩
-                    M + suc l
-                    ≡⟨ +-suc M l ⟩
-                    suc (M + l)
-                    ∎
-
-                  q : (i : Fin l) → sucF (inject+' M i) ≡ cast p (fromℕ M +F sucF i)
-                  q i =
-                    begin
-                    sucF (inject+' M i)
-                    ≡⟨ ≡cong sucF (≡sym (casti≡i {M + l} {≡refl} (inject+' M i))) ⟩
-                    sucF (cast ≡refl (inject+' M i))
-                    ≡⟨ ≡cong sucF ([inject+]≡[+F] i ≡refl (≡cong (λ a → (a + l)) (toℕ-fromℕ M)) ) ⟩
-                    sucF (cast (≡cong (λ a → (a + l)) (toℕ-fromℕ M)) (fromℕ M +F i))
-                    ≡⟨ ≡sym (cast-sucF {toℕ (fromℕ M) + l} {M + l} {(≡cong (λ a → (a + l)) (toℕ-fromℕ M))} {_} (fromℕ M +F i)) ⟩
-                    cast (≡cong (λ a → suc (a + l)) (toℕ-fromℕ M)) (sucF (fromℕ M +F i))
-                    ≡⟨ ≡sym (cast-cast (≡sym (+-suc (toℕ (fromℕ M)) l)) p (≡cong (λ a → suc (a + l)) (toℕ-fromℕ M)) (sucF (fromℕ M +F i))) ⟩
-                    cast p (cast (≡sym (+-suc (toℕ (fromℕ M)) l)) (sucF (fromℕ M +F i)))
-                    ≡⟨ ≡cong (λ i → cast p i) (≡sym (+F-sucF (fromℕ M) i)) ⟩
-                    cast p (fromℕ M +F sucF i)
-                    ∎
-
-                  lem : ∀ {i : Fin (suc l)} →
-                      xs₂ i ≡ xs (cast p (fromℕ M +F i))
-                  lem {zeroF} = begin
-                      xs₂ zeroF
-                      ≡⟨⟩
-                      xs₁ (fromℕ M)
-                      ≡⟨ xs₁i≡xs[inject≤[i][sM≤sN]] (fromℕ M) ⟩
-                      xs (inject≤ (fromℕ M) sM≤sn)
-                      ≡⟨ ≡cong xs (inject≤[fromℕ[a]][a<b]≡cast[fromℕ[a]+F0] sM≤sn p) ⟩
-                      xs (cast p (fromℕ M +F zeroF))
-                      ∎
-                  lem {sucF i} = begin
-                      xs₂ (sucF i)
-                      ≡⟨⟩
-                      xs₂^ i
-                      ≡⟨ xs₂^i≡xs[sucF[cast[inject+'[M][i]]]] i ⟩
-                      xs (sucF (cast ≡refl (inject+' M i)))
-                      ≡⟨ ≡cong (λ j → xs (sucF j)) (casti≡i {M + l} {≡refl} (inject+' M i)) ⟩
-                      xs (sucF (inject+' M i))
-                      ≡⟨ ≡cong xs (q i) ⟩
-                      xs (cast p (fromℕ M +F sucF i))
-                      ∎
-
-            last[xs₂]∈F₁ : NA.accept na₁ (lastF xs₂)
-            last[xs₂]∈F₁ = step-∋ (NA.accept na₁) last[xs]∈F₁ (≡sym last[xs₂]≡last[xs])
+            0            k₁     M         n
+            |------------|------|---------|
+            |              w              |
+            |     w₁            |    w₂   |
+            | w₁↾sk₁≤sM  |      |    w₂   |
+            |     u₁     |       u₂       |
+            |------------|------|---------|
+            0            k₁     M         n
             -}
 
-            a : {!!}
-            a with n-k k₁≤M | w₁i≡wi w₁ k₁≤M
-              | n-k k₁≤n | split w k₁≤n | w₁i≡wi w k₁≤n | w₂i≡w[k+i] {A} {_} {k₁} w k₁≤n
-            a | l' {- = M - k₁ -} , k₁+l≡M | w₁↾≤k₁≡
-              | k₂ , k₁+k₂≡M+l | u₁ , u₂ | u₁i≡ | u₂i≡ = {!!}
-              where
-                {-
-                    c : {X : Set}
-                    → (n : ℕ)
-                    → (w : FinWord n X)
-                    → (l : ℕ) → (k : ℕ)
-                    → (k≤l : k ≤ l) → (l≤n : l ≤ n) → (k≤n : k ≤ n)
-                    → ∀ (i : {!!})
-                    → ((proj₁ (split w l≤n)) ↾ (s≤s k≤l)) i ≡ (proj₁ (split w k≤n)) i
-                -}
-                d = c {A} (M + l) w k₁ M k₁≤M M≤n k₁≤n
-                u₁≡w₁↾≤k : ∀ (i : Fin k₁) →  (w₁ ↾ sk₁≤sM) i ≡ u₁ i
-                u₁≡w₁↾≤k i = begin
-                  (w₁ ↾ sk₁≤sM) i
-                  ≡⟨ {!!} ⟩
-                  {!!}
-                  ≡⟨ d i ⟩
-                  {!!}
-                  ≡⟨ {!!} ⟩
-                  u₁ i
-                  ∎
+            w₁-u₁ : ∀ i →  (w₁ ↾ sk₁≤sM) i ≡ u₁ i
+            w₁-u₁ i = begin
+                (w₁ ↾ sk₁≤sM) i
+                ≡⟨ ≡cong (λ a → (w₁ ↾ a) i) (≡sym (s≤s-≤ k₁≤M sk₁≤sM)) ⟩
+                (w₁ ↾ (s≤s k₁≤M)) i
+                ≡⟨⟩
+                proj₁ (split w₁ k₁≤M) i
+                ≡⟨ w₁i≡wi w₁ k₁≤M i ⟩
+                w₁ (inject≤ i k₁≤M)
+                ≡⟨ w₁i≡w[inject≤[i][M≤n]] (inject≤ i k₁≤M) ⟩
+                w (inject≤ (inject≤ i k₁≤M) M≤n)
+                ≡⟨ ≡cong w (inject≤-idempotent i k₁≤M M≤n k₁≤n) ⟩
+                w (inject≤ i k₁≤n)
+                ≡⟨ ≡sym (w₁i≡wi w k₁≤n i) ⟩
+                u₁ i
+                ∎
+            
+            [u₁,v₁]∈Q : ((k₁ , u₁) , v₁) ∈ ∣Q∣
+            [u₁,v₁]∈Q = step-∋ ∣Q∣ [w₁↾≤k₁,v₁]∈Q 
+                (begin
+                (k₁ , (w₁ ↾ sk₁≤sM)) , v₁
+                ≡⟨ ≡cong (λ a → (k₁ , a) , v₁) (ex w₁-u₁) ⟩
+                (k₁ , u₁) , v₁
+                ∎)
 
-            {-
-            ih = IH l (0<b→sa≤b+a l M 0<M) (xs₁ (fromℕ M)) y {!   !} xs₂ w₂ ≡refl {!   !} last[xs₂]∈F₁ {!   !}
+            k₁+sk₂≡ : toℕ (fromℕ k₁) + suc k₂ ≡ suc (M + l)
+            k₁+sk₂≡ = begin
+                toℕ (fromℕ k₁) + suc k₂
+                ≡⟨ ≡cong (λ a → a + suc k₂) (toℕ-fromℕ k₁) ⟩
+                k₁ + suc k₂
+                ≡⟨ +-suc k₁ k₂ ⟩
+                suc (k₁ + k₂)
+                ≡⟨ ≡cong suc k₁+k₂≡n ⟩
+                suc (M + l)
+                ∎
+
+            zs₂i≡ : ∀ (i : Fin (suc k₂)) → zs₂ i ≡ xs (cast k₁+sk₂≡ (fromℕ k₁ +F i))
+            zs₂i≡ zeroF = begin
+                zs₂ zeroF
+                ≡⟨⟩
+                xs₁ (fromℕ< sk₁≤sM)
+                ≡⟨ xs₁i≡xs[inject≤[i][sM≤sn]] (fromℕ< sk₁≤sM)  ⟩
+                xs (inject≤ (fromℕ< sk₁≤sM) (sM≤sn))
+                ≡⟨ ≡cong xs (inject≤[fromℕ<[sa≤b][b≤c]]≡inject≤[fromℕ[a]][sa≤c] sk₁≤sM sM≤sn sk₁≤sn) ⟩
+                xs (inject≤ (fromℕ k₁) sk₁≤sn)
+                ≡⟨ ≡cong xs (inject≤[fromℕ[a]][a<b]≡cast[fromℕ[a]+F0] sk₁≤sn k₁+sk₂≡) ⟩
+                xs (cast k₁+sk₂≡ (fromℕ k₁ +F zeroF))
+                ∎
+            zs₂i≡ (sucF i) = begin
+                zs₂^ i
+                ≡⟨⟩
+                proj₂ (split xs (s≤s k₁≤n)) i
+                ≡⟨ w₂i≡w[k+i] {X₁} {suc (M + l)} {suc k₁} xs (s≤s k₁≤n) i ⟩ 
+                xs (cast (proj₂ (n-k (s≤s k₁≤n))) (inject+' (suc k₁) i))
+                ≡⟨⟩
+                xs (cast (≡cong suc k₁+k₂≡n) (inject+' (suc k₁) i))
+                ≡⟨ ≡cong xs (cast-inject+'-cast-fromℕ k₂ k₁ (suc (M + l)) i (≡cong suc k₁+k₂≡n) k₁+sk₂≡) ⟩
+                xs (cast k₁+sk₂≡ (fromℕ k₁ +F sucF i))
+                ∎
+
+            last[zs₂]∈F₁ : (zs₂ (fromℕ k₂)) ∈ NA.accept na₁
+            last[zs₂]∈F₁ = step-∋ (NA.accept na₁) last[xs]∈F₁ 
+                (≡sym (begin
+                zs₂ (fromℕ k₂)
+                ≡⟨ zs₂i≡ (fromℕ k₂) ⟩
+                xs (cast k₁+sk₂≡ (fromℕ k₁ +F fromℕ k₂))
+                ≡⟨ ≡cong xs (fromℕ-+F-+-cast (suc (M + l)) k₁ k₂ {k₁+sk₂≡} {≡cong suc k₁+k₂≡n}) ⟩
+                xs (cast (≡cong suc k₁+k₂≡n) (fromℕ (k₁ + k₂)))
+                ≡⟨ ≡cong xs (cast-fromℕ (suc (M + l)) (k₁ + k₂) (M + l) (≡cong suc k₁+k₂≡n) ≡refl k₁+k₂≡n) ⟩
+                xs (cast ≡refl (fromℕ (M + l)))
+                ≡⟨ ≡cong xs (casti≡i {suc (M + l)} {≡refl} (fromℕ (M + l))) ⟩
+                xs (fromℕ (M + l))
+                ∎))
+
+            k₁+k₂≡ : toℕ (fromℕ k₁) + k₂ ≡ M + l
+            k₁+k₂≡ = begin
+                toℕ (fromℕ k₁) + k₂
+                ≡⟨ ≡cong (λ i → i + k₂) (toℕ-fromℕ k₁) ⟩
+                k₁ + k₂
+                ≡⟨ k₁+k₂≡n ⟩
+                M + l
+                ∎
+            
+            xs-zs₂[inject₁i] : ∀ (i : Fin k₂) →  xs (inject₁ (cast k₁+k₂≡ (fromℕ k₁ +F i))) ≡ zs₂ (inject₁ i)
+            xs-zs₂[inject₁i] i = ≡sym (begin
+                zs₂ (inject₁ i)
+                ≡⟨ zs₂i≡ (inject₁ i) ⟩
+                xs (cast k₁+sk₂≡ (fromℕ k₁ +F (inject₁ i)))
+                ≡⟨ ≡cong xs (cast-fromℕ-+F-inject₁ (fromℕ k₁) i k₁+sk₂≡ k₁+k₂≡) ⟩
+                xs (inject₁ (cast k₁+k₂≡ (fromℕ k₁ +F i)))
+                ∎)
+
+            xs-zs₂[si] : ∀ (i : Fin k₂) → xs (sucF (cast k₁+k₂≡ (fromℕ k₁ +F i))) ≡ zs₂ (sucF i)
+            xs-zs₂[si] i = ≡sym (begin
+                zs₂ (sucF i)
+                ≡⟨ zs₂i≡ (sucF i) ⟩ 
+                xs (cast k₁+sk₂≡ (fromℕ k₁ +F (sucF i)))
+                ≡⟨ ≡cong xs (≡sym (s[cast[fromℕ[a]+Fiᵇ]]≡cast[fromℕ[a]+Fsiᵇ] k₁+k₂≡ k₁+sk₂≡)) ⟩
+                xs (sucF (cast k₁+k₂≡ (fromℕ k₁ +F i)))
+                ∎)
+
+            w-u₂[i] : ∀ (i : Fin k₂) → w (cast k₁+k₂≡ (fromℕ k₁ +F i)) ≡ u₂ i
+            w-u₂[i] i = ≡sym (begin
+                u₂ i
+                ≡⟨ w₂i≡w[k+i] {A} {M + l} {k₁} w k₁≤n i  ⟩
+                w (cast k₁+k₂≡n (inject+' k₁ i))
+                ≡⟨ ≡cong w ([inject+]≡[+F] i k₁+k₂≡n k₁+k₂≡) ⟩
+                w (cast k₁+k₂≡ (fromℕ k₁ +F i))
+                ∎)
+
+            tr-zs₂-u₂ : (i : Fin k₂) → (zs₂ (inject₁ i) , u₂ i , zs₂ (sucF i)) ∈ NA.trans na₁
+            tr-zs₂-u₂ i = step-∋ (NA.trans na₁) (tr-xs-w[k₁+i])
+                (begin
+                xs (inject₁ (cast k₁+k₂≡ (fromℕ k₁ +F i))) , w (cast k₁+k₂≡ (fromℕ k₁ +F i)) ,  xs (sucF (cast k₁+k₂≡ (fromℕ k₁ +F i)))
+                ≡⟨ ≡cong (λ a → a , w (cast k₁+k₂≡ (fromℕ k₁ +F i)) , xs (sucF (cast k₁+k₂≡ (fromℕ k₁ +F i))) ) (xs-zs₂[inject₁i] i) ⟩
+                zs₂ (inject₁ i) , w (cast k₁+k₂≡ (fromℕ k₁ +F i)) , xs (sucF (cast k₁+k₂≡ (fromℕ k₁ +F i)))
+                ≡⟨ ≡cong (λ a → zs₂ (inject₁ i) , w (cast k₁+k₂≡ (fromℕ k₁ +F i)) , a) (xs-zs₂[si] i) ⟩
+                zs₂ (inject₁ i) , w (cast k₁+k₂≡ (fromℕ k₁ +F i)) , zs₂ (sucF i)
+                ≡⟨ ≡cong (λ a → zs₂ (inject₁ i) , a , zs₂ (sucF i)) (w-u₂[i] i) ⟩
+                zs₂ (inject₁ i) , u₂ i , zs₂ (sucF i)
+                ∎)
                 where
-                    0<b→sa≤b+a : (a b : ℕ) → 0 < b → suc a ≤ b + a
-                    0<b→sa≤b+a zero .(suc _) (s≤s 0<b) = s≤s z≤n
-                    0<b→sa≤b+a (suc a) .(suc _) (s≤s 0<b) = s≤s (m≤n+m (suc a) _)
-                    -}
+                    tr-xs-w[k₁+i] : NA.trans na₁
+                        ( xs (inject₁ (cast k₁+k₂≡ (fromℕ k₁ +F i)))
+                        , w (cast k₁+k₂≡ (fromℕ k₁ +F i))
+                        , xs (sucF (cast k₁+k₂≡ (fromℕ k₁ +F i)))
+                        )
+                    tr-xs-w[k₁+i] = tr-xs-w (cast k₁+k₂≡ (fromℕ k₁ +F i))
+
+            {- Use induction hypothesis IH -}
+            ih : ∃[ v₂ ] {- v₂ : FINWord A -}
+                ∃[ y'' ] {- y'' : X₂ -}
+                ((k₂ , u₂) , v₂) ∈ ∣Q∣
+                × (v₂ ∈ FINWord-from[ y' ]to[ y'' ] na₂)
+                × (y'' ∈ NA.accept na₂)
+            ih = IH k₂ sk₂≤n (xs₁ (fromℕ< sk₁≤sM)) y' [xs₁[fromℕ<[sk₁≤sM]],y']∈R zs₂ u₂ ≡refl tr-zs₂-u₂ last[zs₂]∈F₁ k₂<N
+                where
+                    sk₂≤n : suc k₂ ≤ M + l
+                    sk₂≤n = a+b≡c→a≢0→sb≤c k₁ k₂ (M + l) k₁+k₂≡n k₁≢0
+                        where
+                            a+b≡c→a≢0→sb≤c : ∀ (a b c : ℕ) → a + b ≡ c → a ≢  zero → suc b ≤ c
+                            a+b≡c→a≢0→sb≤c zero b .(zero + b) ≡refl zero≢zero with zero≢zero ≡refl
+                            a+b≡c→a≢0→sb≤c zero b .(zero + b) ≡refl zero≢zero | ()
+                            a+b≡c→a≢0→sb≤c (suc a) b .(suc a + b) ≡refl _ = s≤s (m≤n+m b a)
+
+                    k₂<N : suc k₂ ≤ N
+                    k₂<N = ≤-trans sk₂≤n (<⇒≤ n<N)
+
+            construction :
+                ∃[ v₁v₂ ] {- v₁v₂ : FINWord A -}
+                ∃[ y'' ] {- y'' : X₂ -}
+                (((M + l) , w) , v₁v₂) ∈ ∣Q∣
+                × (v₁v₂ ∈ FINWord-from[ y ]to[ y'' ] na₂)
+                × (y'' ∈ NA.accept na₂)
+            construction with ih
+            construction | v₂ , y'' , [u₂,v₂]∈Q , y'⇝[v₂]y'' , y''∈F₂
+                with v₂ | y'⇝[v₂]y''
+            construction | v₂ , y'' , [u₂,v₂]∈Q , y'⇝[v₂]y'' , y''∈F₂
+                | l₂ , v₂' | ys₂ , ys₂0≡y' , tr-ys₂-v₂ , last[ys₂]≡y'' =
+                ((l₁ + l₂ , v₁'v₂') , y'' , [w,v₁v₂]∈Q , (ys₁·ys₂ , ys₁·ys₂0≡ys0  , tr-ys₁·ys₂-v₁v₂ , last[ys₁·ys₂]≡y'') , y''∈F₂)
+                where
+                    l₁ = proj₁ v₁
+                    v₁' = proj₂ v₁
+                    
+                    v₁'v₂' : FinWord (l₁ + l₂) A
+                    v₁'v₂' = concat v₁' v₂'
+
+                    ys₁ : FinWord (suc l₁) X₂
+                    ys₁ = proj₁ y⇝[v₁]y'
+
+                    last[ys₁]≡y' : ys₁ (fromℕ l₁) ≡ y'
+                    last[ys₁]≡y' = proj₂ (proj₂ (proj₂ y⇝[v₁]y'))
+
+                    ys₁·ys₂ : FinWord (suc (l₁ + l₂)) X₂
+                    ys₁·ys₂ = concat ys₁ (tailF ys₂)
+
+                    ys₁·ys₂0≡ys0 : ys₁·ys₂ zeroF ≡ y
+                    ys₁·ys₂0≡ys0 = begin
+                        ys₁ zeroF
+                        ≡⟨ proj₁ (proj₂ y⇝[v₁]y') ⟩
+                        y
+                        ∎
+
+                    ys₂0≡last[ys₁] : ys₂ zeroF ≡ ys₁ (fromℕ l₁)
+                    ys₂0≡last[ys₁] = begin
+                        ys₂ zeroF
+                        ≡⟨ ys₂0≡y' ⟩
+                        y'
+                        ≡⟨ ≡sym last[ys₁]≡y' ⟩
+                        ys₁ (fromℕ l₁)
+                        ∎
+
+                    last[ys₁·ys₂]≡y'' : ys₁·ys₂ (fromℕ (l₁ + l₂)) ≡ y''
+                    last[ys₁·ys₂]≡y'' = begin
+                        ys₁·ys₂ (fromℕ (l₁ + l₂))
+                        ≡⟨ ≡sym (last-concat {X₂} {l₁} {l₂} ys₁ ys₂ ys₂0≡last[ys₁]) ⟩
+                        ys₂ (fromℕ l₂)
+                        ≡⟨ last[ys₂]≡y'' ⟩
+                        y''
+                        ∎
+
+                    tr-ys₁-v₁ : (i : Fin l₁) → (ys₁ (inject₁ i) , v₁' i , ys₁ (sucF i)) ∈ NA.trans na₂
+                    tr-ys₁-v₁ = proj₁ (proj₂ (proj₂ y⇝[v₁]y'))
+
+                    open QSimulation.Lemma.Transition X₂ A na₂ l₁ l₂ ys₁ ys₂ ys₂0≡last[ys₁] v₁' v₂' tr-ys₁-v₁ tr-ys₂-v₂
+                    tr-ys₁·ys₂-v₁v₂ : (i : Fin (l₁ + l₂)) → NA.trans na₂ (ys₁·ys₂ (inject₁ i) , concat v₁' v₂' i , ys₁·ys₂ (sucF i))
+                    tr-ys₁·ys₂-v₁v₂ i = tr i
+
+                    [w,v₁v₂]∈Q : ((M + l , w) , (l₁ + l₂ , v₁'v₂')) ∈ ∣Q∣
+                    [w,v₁v₂]∈Q = step-∋ ∣Q∣
+                        (Q-is-closed-under-concat ((k₁ , u₁) , (l₁ , v₁')) [u₁,v₁]∈Q ((k₂ , u₂) , (l₂ , v₂')) [u₂,v₂]∈Q)
+                        (begin
+                        (k₁ + k₂ , concat u₁ u₂) , (l₁ + l₂ , v₁'v₂')
+                        ≡⟨ ≡cong (λ a → (k₁ + k₂ , a) , (l₁ + l₂ , v₁'v₂')) ([concat-split-w]≡w' w k₁≤n) ⟩
+                        (k₁ + k₂ , λ i → w (cast k₁+k₂≡n i)) , (l₁ + l₂ , v₁'v₂')
+                        ≡⟨ ≡cong (λ a → a , (l₁ + l₂ , v₁'v₂')) (≡sym (inj[m][w]≡inj[n][λi→w[cast[i]]] (M + l) (k₁ + k₂) w k₁+k₂≡n)) ⟩
+                        (M + l , w) , (l₁ + l₂ , v₁'v₂')
+                        ∎)
 
     finalN : ∀ x y → (x , y) ∈ R → Final[ N ][ Q ] R x y
     finalN x y [x,y]∈R n = <-rec (λ n → _) lemma n x y [x,y]∈R 

--- a/src/QSimulation/Bounded.agda
+++ b/src/QSimulation/Bounded.agda
@@ -162,8 +162,8 @@ module Lemma
     (Q@(aPreorder ∣Q∣ _ _) : Preorder)
     (Q-is-closed-under-concat : [ Q ]-is-closed-under-concat)
     (R : Pred' (X₁ × X₂))
-    (stepM : ∀ x y → (x , y) ∈ R → Step[ M ][ Q ] R x y)
-    (finalM : ∀ x y → (x , y) ∈ R → Final[ M ][ Q ] R x y)
+    (StepM : ∀ x y → (x , y) ∈ R → Step[ M ][ Q ] R x y)
+    (FinalM : ∀ x y → (x , y) ∈ R → Final[ M ][ Q ] R x y)
     where
 
     k≤n⊎n<k : (k n : ℕ) → (k ≤ n) ⊎ (n < k)
@@ -172,6 +172,15 @@ module Lemma
     k≤n⊎n<k (suc k) (suc n) with k≤n⊎n<k k n
     k≤n⊎n<k (suc k) (suc n) | inj₁ k≤n = inj₁ (s≤s k≤n)
     k≤n⊎n<k (suc k) (suc n) | inj₂ n<k = inj₂ (s≤s n<k)
+
+    c : {X : Set}
+      → (n : ℕ)
+      → (w : FinWord n X)
+      → (p : ℕ) → (q : ℕ)
+      → (p≤q : p ≤ q) → (q≤n : q ≤ n) → (p≤n : p ≤ n)
+      → ∀ (i : Fin p)
+      → ((proj₁ (split w q≤n)) ↾ (s≤s p≤q)) i ≡ (proj₁ (split w p≤n)) i
+    c = {!!}
 
     lemma :
         (n : ℕ)
@@ -204,7 +213,7 @@ module Lemma
     lemma n _ x y [x,y]∈R xs w ≡refl tr last[xs]∈F₁ n<N
         -- base case
         | inj₁ sn≤M =
-            finalM x y [x,y]∈R n xs w ≡refl tr last[xs]∈F₁ sn≤M
+            FinalM x y [x,y]∈R n xs w ≡refl tr last[xs]∈F₁ sn≤M
     lemma n rec x y [x,y]∈R xs w ≡refl tr last[xs]∈F₁ n<N
         -- step case
         | inj₂ sM≤sn@(s≤s M≤n)
@@ -216,19 +225,81 @@ module Lemma
         | inj₂ sM≤sn@(s≤s M≤n)
         | l , ≡refl
         | xs₁ , xs₂^ | xs₁i≡xs[inject≤[i][sM≤sN]] | xs₂^i≡xs[sucF[cast[inject+'[M][i]]]]
-        | w₁ , w₂ | w₁i≡w[inject≤[i][M≤N]] | w₂i≡w[sucF[cast[inject+'[M][i]]]] = ({!   !} , {!   !} , {!   !} , {!   !} , {!   !})
+        | w₁ , w₂ | w₁i≡w[inject≤[i][M≤N]] | w₂i≡w[sucF[cast[inject+'[M][i]]]] =
+        {!!}
         where
+            [xs₁0,y]∈R : (xs₁ zeroF , y) ∈ R
+            [xs₁0,y]∈R = step-∋ R [x,y]∈R (≡cong (λ a → (a , y)) (≡sym xs₁0≡xs0))
+              where
+                xs₁0≡xs0 : xs₁ zeroF ≡ xs zeroF
+                xs₁0≡xs0 =
+                  begin
+                  xs₁ zeroF
+                  ≡⟨ xs₁i≡xs[inject≤[i][sM≤sN]] zeroF ⟩
+                  xs zeroF
+                  ∎
+
+            tr₁ : (i : Fin M)
+              → (xs₁ (inject₁ i) , w₁ i , xs₁ (sucF i)) ∈ NA.trans na₁
+            tr₁ i = step-∋ (NA.trans na₁) (tr (inject≤ i M≤n))
+              (begin
+              xs (inject₁ (inject≤ i M≤n)) , w (inject≤ i M≤n) , xs (sucF (inject≤ i M≤n))
+              ≡⟨ ≡cong (λ a → (a , _ , _)) (≡sym p) ⟩
+              xs₁ (inject₁ i) , w (inject≤ i M≤n) , xs (sucF (inject≤ i M≤n))
+              ≡⟨ ≡cong (λ a → (_ , _ , a)) (≡sym (xs₁i≡xs[inject≤[i][sM≤sN]] (sucF i))) ⟩
+              xs₁ (inject₁ i) , w (inject≤ i M≤n) , xs₁ (sucF i)
+              ≡⟨ ≡cong (λ a → (_ , a , _)) (≡sym (w₁i≡w[inject≤[i][M≤N]] i)) ⟩
+              xs₁ (inject₁ i) , w₁ i , xs₁ (sucF i)
+              ∎)
+              where
+                p : xs₁ (inject₁ i) ≡ xs (inject₁ (inject≤ i M≤n))
+                p =
+                  begin
+                  xs₁ (inject₁ i)
+                  ≡⟨ xs₁i≡xs[inject≤[i][sM≤sN]] (inject₁ i) ⟩
+                  xs (inject≤ (inject₁ i) (s≤s M≤n))
+                  ≡⟨ ≡cong xs (inject≤inject₁≡inject₁inject≤ M≤n) ⟩
+                  xs (inject₁ (inject≤ i M≤n))
+                  ∎
+
+            stepM = StepM (xs₁ zeroF) y  [xs₁0,y]∈R xs₁ w₁ ≡refl tr₁
+
+            k₁ : ℕ
+            k₁ = proj₁ stepM
+
+            k₁≢0 : k₁ ≢ 0
+            k₁≢0 = proj₁ (proj₂ stepM)
+
+            sk₁≤sM : suc k₁ ≤ suc M
+            sk₁≤sM = proj₁ (proj₂ (proj₂ stepM))
+
+            k₁≤M : k₁ ≤ M
+            k₁≤M = ≤-pred sk₁≤sM
+
+            sk₁≤sn  : suc k₁ ≤ suc (M + l)
+            sk₁≤sn = ≤-trans sk₁≤sM sM≤sn
+
+            k₁≤n : k₁ ≤ M + l
+            k₁≤n = ≤-pred sk₁≤sn
+
+            w' : FINWord A
+            w' = proj₁ (proj₂ (proj₂ (proj₂ stepM)))
+
+            y' : X₂
+            y' = proj₁ (proj₂ (proj₂ (proj₂ (proj₂ stepM))))
+
+            [w₁↾≤k₁,w']∈Q : ((k₁ , (w₁ ↾ sk₁≤sM)) , w') ∈ ∣Q∣
+            [w₁↾≤k₁,w']∈Q = proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ stepM)))))
+
+            y⇝[w']y' = proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ stepM))))))
+
+            [xs₁[fromℕ<[sk₁≤sM]],y']∈R : (xs₁ (fromℕ< sk₁≤sM) , y') ∈ R
+            [xs₁[fromℕ<[sk₁≤sM]],y']∈R =
+              proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ stepM))))))
+
+            {-
             xs₂ : FinWord (suc l) X₁
             xs₂ = (xs₁ (fromℕ M)) ∷ᶠ xs₂^
-
-            toℕfromℕM+sl≡s[M+l] : toℕ (fromℕ M) + suc l ≡ suc (M + l)
-            toℕfromℕM+sl≡s[M+l] = begin
-                toℕ (fromℕ M) + suc l
-                ≡⟨ ≡cong (λ i → i + suc l) (toℕ-fromℕ M) ⟩
-                M + suc l
-                ≡⟨ +-suc M l ⟩
-                suc (M + l)
-                ∎
 
             last[xs₂]≡last[xs] : lastF xs₂ ≡ lastF xs
             last[xs₂]≡last[xs] = begin
@@ -266,15 +337,15 @@ module Lemma
                     ∎
 
                   lem : ∀ {i : Fin (suc l)} →
-                      xs₂ i ≡ xs (cast toℕfromℕM+sl≡s[M+l] (fromℕ M +F i))
+                      xs₂ i ≡ xs (cast p (fromℕ M +F i))
                   lem {zeroF} = begin
                       xs₂ zeroF
                       ≡⟨⟩
                       xs₁ (fromℕ M)
                       ≡⟨ xs₁i≡xs[inject≤[i][sM≤sN]] (fromℕ M) ⟩
                       xs (inject≤ (fromℕ M) sM≤sn)
-                      ≡⟨ ≡cong xs (inject≤[fromℕ[a]][a<b]≡cast[fromℕ[a]+F0] sM≤sn toℕfromℕM+sl≡s[M+l]) ⟩
-                      xs (cast toℕfromℕM+sl≡s[M+l] (fromℕ M +F zeroF))
+                      ≡⟨ ≡cong xs (inject≤[fromℕ[a]][a<b]≡cast[fromℕ[a]+F0] sM≤sn p) ⟩
+                      xs (cast p (fromℕ M +F zeroF))
                       ∎
                   lem {sucF i} = begin
                       xs₂ (sucF i)
@@ -290,12 +361,42 @@ module Lemma
 
             last[xs₂]∈F₁ : NA.accept na₁ (lastF xs₂)
             last[xs₂]∈F₁ = step-∋ (NA.accept na₁) last[xs]∈F₁ (≡sym last[xs₂]≡last[xs])
+            -}
 
-            ih = IH l (0<b→sa≤b+a l M 0<M) (xs₁ (fromℕ M)) {!   !} {!   !} xs₂ w₂ ≡refl {!   !} last[xs₂]∈F₁ {!   !}
+            a : {!!}
+            a with n-k k₁≤M | w₁i≡wi w₁ k₁≤M
+              | n-k k₁≤n | split w k₁≤n | w₁i≡wi w k₁≤n | w₂i≡w[k+i] {A} {_} {k₁} w k₁≤n
+            a | l' {- = M - k₁ -} , k₁+l≡M | w₁↾≤k₁≡
+              | k₂ , k₁+k₂≡M+l | u₁ , u₂ | u₁i≡ | u₂i≡ = {!!}
+              where
+                {-
+                    c : {X : Set}
+                    → (n : ℕ)
+                    → (w : FinWord n X)
+                    → (l : ℕ) → (k : ℕ)
+                    → (k≤l : k ≤ l) → (l≤n : l ≤ n) → (k≤n : k ≤ n)
+                    → ∀ (i : {!!})
+                    → ((proj₁ (split w l≤n)) ↾ (s≤s k≤l)) i ≡ (proj₁ (split w k≤n)) i
+                -}
+                d = c {A} (M + l) w k₁ M k₁≤M M≤n k₁≤n
+                u₁≡w₁↾≤k : ∀ (i : Fin k₁) →  (w₁ ↾ sk₁≤sM) i ≡ u₁ i
+                u₁≡w₁↾≤k i = begin
+                  (w₁ ↾ sk₁≤sM) i
+                  ≡⟨ {!!} ⟩
+                  {!!}
+                  ≡⟨ d i ⟩
+                  {!!}
+                  ≡⟨ {!!} ⟩
+                  u₁ i
+                  ∎
+
+            {-
+            ih = IH l (0<b→sa≤b+a l M 0<M) (xs₁ (fromℕ M)) y {!   !} xs₂ w₂ ≡refl {!   !} last[xs₂]∈F₁ {!   !}
                 where
                     0<b→sa≤b+a : (a b : ℕ) → 0 < b → suc a ≤ b + a
                     0<b→sa≤b+a zero .(suc _) (s≤s 0<b) = s≤s z≤n
                     0<b→sa≤b+a (suc a) .(suc _) (s≤s 0<b) = s≤s (m≤n+m (suc a) _)
+                    -}
 
     finalN : ∀ x y → (x , y) ∈ R → Final[ N ][ Q ] R x y
     finalN x y [x,y]∈R n = <-rec (λ n → _) lemma n x y [x,y]∈R 

--- a/src/QSimulation/Bounded.agda
+++ b/src/QSimulation/Bounded.agda
@@ -1,0 +1,130 @@
+open import NA.Base
+module QSimulation.Bounded
+    (X₁ X₂ A : Set)
+    (na₁@(anNA ⇝₁ _ F₁) : NA X₁ A)
+    (na₂@(anNA ⇝₂ _ F₂) : NA X₂ A)
+    where
+
+open import Base
+open import Data.Nat
+open import Data.Nat.Properties
+    using (≤-trans)
+open import Data.Fin
+    using (Fin; inject₁; inject≤; fromℕ; fromℕ<; toℕ; cast)
+    renaming (zero to zeroF; suc to sucF; _+_ to _+F_)
+open import Relation.Binary.PropositionalEquality
+    using (_≡_; _≢_; inspect; [_])
+    renaming (refl to ≡refl; sym to ≡sym; cong to ≡cong)
+open Relation.Binary.PropositionalEquality.≡-Reasoning
+open import Relation.Unary using (_∈_)
+open import Data.Product using (_×_; _,_; ∃; ∃-syntax; proj₁; proj₂)
+
+open import Base
+open import FinForWord
+open import Word
+open import NA
+open import QSimulation.Base
+open QSimulation.Base.ConditionOnQ A
+open QSimulation.Base.QSimulationBase A X₁ X₂ na₁ na₂
+open import QSimulation.Lemma using (inject≤inject₁≡inject₁inject≤)
+
+M≤N⇒FinalN⇒FinalM :
+    ∀ {M N : ℕ} → M ≤ N
+    → (Q : Preorder)
+    → (R : Pred' (X₁ × X₂)) → (x : X₁) → (y : X₂)
+    → Final[ N ][ Q ] R x y
+    → Final[ M ][ Q ] R x y
+M≤N⇒FinalN⇒FinalM
+    {M} {N} M≤N Q R .(xs zeroF) y finalN
+    n xs w ≡refl tr tailx∈F₁ n<M =
+    finalN n xs w ≡refl tr tailx∈F₁ (≤-trans n<M M≤N)
+
+M≤N⇒StepM⇒StepN :
+    ∀ {M N : ℕ} → M ≤ N
+    → (Q : Preorder)
+    → (R : Pred' (X₁ × X₂)) → (x : X₁) → (y : X₂)
+    → Step[ M ][ Q ] R x y
+    → Step[ N ][ Q ] R x y
+M≤N⇒StepM⇒StepN {M} {N} M≤N Q R .(xs zeroF) y StepM xs w ≡refl tr
+    with split w M≤N | w₁i≡wi w M≤N
+M≤N⇒StepM⇒StepN {M} {N} M≤N Q R .(xs zeroF) y StepM xs w ≡refl tr
+    | w↾<M , w↾≥M | w↾<Mi≡wi
+    with split xs (s≤s M≤N) | w₁i≡wi xs (s≤s M≤N)
+M≤N⇒StepM⇒StepN {M} {N} M≤N Q@(aPreorder ∣Q∣ _ _) R .(xs zeroF) y StepM xs w ≡refl tr
+    | w↾<M , w↾≥M | w↾<Mi≡wi
+    | xs↾≤M , xs↾>M | xs↾≤Mi≡xsi =
+    (k , k≢0 , sk≤sN , w' , y' , [w↾sk≤sN,w']∈Q , y⇝[w']y' , {!  !} )
+    where
+        -- xs↾≤Mi≡xsi : (i : Fin (suc M)) → xs≤M i ≡ xs (inject≤ i (s≤s M≤N))
+        xs0≡xs↾≤M0 : (xs zeroF) ≡ (xs↾≤M zeroF)
+        xs0≡xs↾≤M0 = begin xs zeroF ≡⟨ ≡sym (xs↾≤Mi≡xsi zeroF) ⟩ xs↾≤M zeroF ∎
+
+        tr↾≤M : (i : Fin M) → (xs↾≤M (inject₁ i) , w↾<M i , xs↾≤M (sucF i)) ∈ NA.trans na₁
+        tr↾≤M i = step-∋ (NA.trans na₁) (tr (inject≤ i M≤N)) 
+            (begin
+                xs (inject₁ (inject≤ i M≤N)) , w (inject≤ i M≤N) , xs (sucF (inject≤ i M≤N))
+                ≡⟨ ≡cong (λ a → a , w (inject≤ i M≤N) , xs (sucF (inject≤ i M≤N))) (≡sym p) ⟩
+                xs↾≤M (inject₁ i) , w (inject≤ i M≤N) , xs (sucF (inject≤ i M≤N))
+                ≡⟨ ≡cong (λ a → xs↾≤M (inject₁ i) , w (inject≤ i M≤N) , a) (≡sym (xs↾≤Mi≡xsi (sucF i))) ⟩
+                xs↾≤M (inject₁ i) , w (inject≤ i M≤N) , xs↾≤M (sucF i)
+                ≡⟨ ≡cong (λ a → xs↾≤M (inject₁ i) , a ,  xs↾≤M (sucF i)) (≡sym (w↾<Mi≡wi i)) ⟩
+                xs↾≤M (inject₁ i) , w↾<M i , xs↾≤M (sucF i)
+            ∎)
+            where
+                p : xs↾≤M (inject₁ i) ≡ xs (inject₁ (inject≤ i M≤N))
+                p = begin
+                    xs↾≤M (inject₁ i)
+                    ≡⟨ xs↾≤Mi≡xsi (inject₁ i) ⟩
+                    xs (inject≤ (inject₁ i) (s≤s M≤N))
+                    ≡⟨ ≡cong xs (inject≤inject₁≡inject₁inject≤ M≤N) ⟩
+                    xs (inject₁ (inject≤ i M≤N))
+                    ∎
+
+        stepM = StepM xs↾≤M w↾<M xs0≡xs↾≤M0 tr↾≤M
+        k : ℕ
+        k = proj₁ stepM
+        k≢0 = proj₁ (proj₂ stepM)
+
+        sk≤sM : suc k ≤ suc M
+        sk≤sM = proj₁ (proj₂ (proj₂ stepM))
+
+        sk≤sN : suc k ≤ suc N
+        sk≤sN = ≤-trans sk≤sM (s≤s M≤N)
+
+        w' : FINWord A
+        w' = proj₁ (proj₂ (proj₂ (proj₂ stepM)))
+
+        y' : X₂
+        y' = proj₁ (proj₂ (proj₂ (proj₂ (proj₂ stepM))))
+
+        [w↾<M↾≤k,w']∈Q : ((k , (w↾<M ↾ sk≤sM)) , w') ∈ ∣Q∣
+        [w↾<M↾≤k,w']∈Q = proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ stepM)))))
+        
+
+        a : {n m k : ℕ} → (m≤n : m ≤ n) → (sk≤sm : suc k ≤ suc m)
+            → (sk≤sn : suc k ≤ suc n)
+            → (u' : Fin m → A) → (u : Fin n → A)
+            → ((i : Fin m) → u' i ≡ u (inject≤ i m≤n))
+            → (i : Fin k)
+            → (u' ↾ sk≤sm) i ≡ (u ↾ sk≤sn) i
+        a {n} {m} {k} m≤n sk≤sm sk≤sn u' u p i = {!   !}
+
+
+        w↾<M↾≤k[i]≡w↾≤sN↾<k[i] : (i : Fin k) → (w↾<M ↾ sk≤sM) i ≡ (w ↾ sk≤sN) i
+        w↾<M↾≤k[i]≡w↾≤sN↾<k[i] i = begin
+            (w↾<M ↾ sk≤sM) i
+            ≡⟨ {!   !} ⟩
+            (w ↾ sk≤sN) i
+            ∎
+        -- (i : Fin M) → w i ≡ w' (inject≤ i M≤N)
+
+        [w↾sk≤sN,w']∈Q : (( k , w ↾ sk≤sN ) , w') ∈ ∣Q∣
+        [w↾sk≤sN,w']∈Q = step-∋ ∣Q∣ [w↾<M↾≤k,w']∈Q
+            (begin
+            ((k , w↾<M ↾ sk≤sM ) , w')
+            ≡⟨ ≡cong (λ a → ((k , a), w')) (ex w↾<M↾≤k[i]≡w↾≤sN↾<k[i]) ⟩
+            ((k , w ↾ sk≤sN ) , w')
+            ∎)
+
+        y⇝[w']y' = proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ (proj₂ stepM))))))
+

--- a/src/QSimulation/Lemma.agda
+++ b/src/QSimulation/Lemma.agda
@@ -63,6 +63,31 @@ inject≤inject₁≡inject₁inject≤ {.(suc _)} {.(suc _)} {sucF i} (s≤s m�
   sucF (inject₁ (inject≤ i m≤n))
   ∎
 
+inject≤[inject≤[i][k≤m]][m≤n]≡inject≤[i][k≤n] : {k m n : ℕ}
+  → (i : Fin k)
+  → (k≤m : k ≤ m) → (m≤n : m ≤ n) → (k≤n : k ≤ n)
+  → inject≤ (inject≤ i k≤m) m≤n ≡ inject≤ i k≤n
+inject≤[inject≤[i][k≤m]][m≤n]≡inject≤[i][k≤n] {.(suc _)} {suc m} {suc n} zeroF k≤sm sm≤sn k≤sn = ≡refl
+inject≤[inject≤[i][k≤m]][m≤n]≡inject≤[i][k≤n] {.(suc _)} {suc m} {suc n} (sucF i) k≤m m≤n k≤n =
+  begin
+  sucF (inject≤ (inject≤ i (≤-pred k≤m)) (≤-pred m≤n))
+  ≡⟨ ≡cong sucF (inject≤[inject≤[i][k≤m]][m≤n]≡inject≤[i][k≤n] i (≤-pred k≤m) (≤-pred m≤n) (≤-pred k≤n)) ⟩
+  sucF (inject≤ i (≤-pred k≤n))
+  ∎
+
+inject≤[fromℕ<[a≤b]][b≤c]≡fromℕ<[a≤c] : {a b c : ℕ}
+  → (sa≤b : suc a ≤ b)
+  → (b≤c : b ≤ c)
+  → (sa≤c : suc a ≤ c)
+  → inject≤ (fromℕ< sa≤b) (b≤c) ≡ fromℕ< sa≤c
+inject≤[fromℕ<[a≤b]][b≤c]≡fromℕ<[a≤c] {zero} {suc b} {suc c} (s≤s a≤b) (s≤s b≤c) (s≤s a≤c) = ≡refl
+inject≤[fromℕ<[a≤b]][b≤c]≡fromℕ<[a≤c] {suc a} {suc b} {suc c} (s≤s a≤b) (s≤s b≤sc) (s≤s a≤c) =
+  begin
+  sucF (inject≤ (fromℕ< a≤b) b≤sc)
+  ≡⟨ ≡cong sucF (inject≤[fromℕ<[a≤b]][b≤c]≡fromℕ<[a≤c] a≤b b≤sc a≤c) ⟩
+  sucF (fromℕ< a≤c)
+  ∎
+
 inject≤[fromℕ[sa]][sa<sb]≡s[fromℕ<[a<b]] : {a b : ℕ}
   → (ssa≤sb : suc (suc a) ≤ suc b)
   → (sa≤b : suc a ≤ b)
@@ -261,3 +286,4 @@ module Transition
       ≡⟨ ≡cong (λ a → y·y' (inject₁ i) , concat w w' i , a) y'[sj']≡tail[y]·y'[i] ⟩
       y·y' (inject₁ i) , concat w w' i , concat (tailF y) (tailF y') i
       ∎)
+ 

--- a/src/QSimulation/Lemma.agda
+++ b/src/QSimulation/Lemma.agda
@@ -103,6 +103,25 @@ cast-cast {suc n} {.(suc n)} {.(suc n)} ≡refl ≡refl ≡refl (sucF i) =
   cast (≡sym (+-suc (suc (toℕ i)) (suc n))) (sucF (sucF (i +F (sucF j))))
   ∎
 
+fromℕ-+F-+ : (m n : ℕ)
+  → {p : toℕ (fromℕ m) + suc n ≡ suc (m + n)}
+  → cast p (fromℕ m +F fromℕ n) ≡ fromℕ (m + n)
+fromℕ-+F-+ zero zero {p} = ≡refl
+fromℕ-+F-+ zero (suc n) {p} = begin
+  cast p (fromℕ zero +F fromℕ (suc n))
+  ≡⟨⟩
+  sucF (cast (≡cong (λ z → z ∸ 1) p) (fromℕ n))
+  ≡⟨ ≡cong sucF (casti≡i {suc n} {≡refl} (fromℕ n)) ⟩
+  sucF (fromℕ n)
+  ∎
+fromℕ-+F-+ (suc m) n {p} = begin
+  cast p (fromℕ (suc m) +F fromℕ n)
+  ≡⟨⟩
+  sucF (cast (≡cong (λ z → z ∸ 1) p) (fromℕ m +F fromℕ n))
+  ≡⟨ ≡cong sucF (fromℕ-+F-+ m n {≡cong (λ z → z ∸ 1) p}) ⟩
+  sucF (fromℕ (m + n))
+  ∎
+
 inject≤inject₁≡inject₁inject≤ : ∀ {m n} {i : Fin m} → (m≤n : m ≤ n)
   → inject≤ (inject₁ i) (s≤s m≤n) ≡ inject₁ (inject≤ i m≤n)
 inject≤inject₁≡inject₁inject≤ {.(suc _)} {.(suc _)} {zeroF} (s≤s m≤n) = ≡refl

--- a/src/QSimulation/Lemma.agda
+++ b/src/QSimulation/Lemma.agda
@@ -49,9 +49,59 @@ ss[k'+l']≡ss[k'+l]→l'≡l {suc k'} {l'} {l} p =
 
 
 -- conversion of index of type `Fin m`
-toℕfromℕ≡id : ∀ (i : ℕ) → toℕ (fromℕ i) ≡ i
-toℕfromℕ≡id zero = ≡refl
-toℕfromℕ≡id (suc i) = ≡cong suc (toℕfromℕ≡id i)
+casti≡i : ∀ {n : ℕ} → {p : n ≡ n} → (i : Fin n) → cast p i ≡ i
+casti≡i {suc n} {≡refl} zeroF = ≡refl
+casti≡i {suc n} {≡refl} (sucF i) = ≡cong sucF (casti≡i {n} {≡refl} i)
+
+cast-sucF : ∀ {n m : ℕ} {p : n ≡ m} {q : suc n ≡ suc m} → (i : Fin n)
+  → cast q (sucF i) ≡ sucF (cast p i)
+cast-sucF {n} {.n} {≡refl} {≡refl} i = ≡refl
+
+cast-cast : ∀ {l m n : ℕ}
+  → (p : l ≡ m) → (q : m ≡ n) → (r : l ≡ n)
+  → (i : Fin l)
+  → cast q (cast p i) ≡ cast r i
+cast-cast ≡refl ≡refl ≡refl zeroF = ≡refl
+cast-cast {suc n} {.(suc n)} {.(suc n)} ≡refl ≡refl ≡refl (sucF i) =
+  begin
+  cast ≡refl (cast ≡refl (sucF i))
+  ≡⟨ ≡cong (λ j → cast ≡refl j) (cast-sucF {n} {n} {≡refl} {≡refl} i) ⟩
+  cast ≡refl (sucF (cast ≡refl i))
+  ≡⟨ cast-sucF {n} {n} {≡refl} {≡refl} (cast ≡refl i) ⟩
+  sucF (cast ≡refl (cast ≡refl i))
+  ≡⟨ ≡cong sucF (cast-cast ≡refl ≡refl ≡refl i) ⟩
+  sucF (cast ≡refl i)
+  ≡⟨ ≡refl ⟩
+  cast ≡refl (sucF i)
+  ∎
+
++F-sucF : ∀ {m n : ℕ} (i : Fin m) (j : Fin n)
+  → i +F sucF j ≡ cast (≡sym (+-suc (toℕ i) n)) (sucF (i +F j))
++F-sucF {suc m} {suc n} zeroF zeroF = ≡refl
++F-sucF {suc m} {suc n} zeroF (sucF j) =
+  begin
+  sucF (sucF j)
+  ≡⟨ ≡cong sucF (≡sym (casti≡i {suc n} {≡refl} (sucF j))) ⟩
+  sucF (cast ≡refl (sucF j))
+  ≡⟨ ≡sym (cast-sucF {suc n} {suc n} {≡refl} {≡refl} (sucF j)) ⟩
+  cast ≡refl (sucF (sucF j))
+  ∎
++F-sucF {suc m} {suc n} (sucF i) zeroF =
+  begin
+  sucF (i +F sucF zeroF)
+  ≡⟨ ≡cong sucF (+F-sucF i zeroF) ⟩
+  sucF (cast _ (sucF i +F zeroF))
+  ≡⟨ ≡sym (cast-sucF {suc (toℕ i + suc n)} {toℕ i + suc (suc n)} {≡sym (+-suc (toℕ i) (suc n))} {≡sym (+-suc (suc (toℕ i)) (suc n))} (sucF i +F zeroF)) ⟩
+  cast (≡sym (+-suc (suc (toℕ i)) (suc n))) (sucF (sucF i +F zeroF))
+  ∎
++F-sucF {suc m} {suc n} (sucF i) (sucF j) =
+  begin
+  sucF (i +F sucF (sucF j))
+  ≡⟨ ≡cong sucF (+F-sucF i (sucF j)) ⟩
+  sucF (cast (≡sym (+-suc (toℕ i) (suc n))) (sucF (i +F (sucF j))))
+  ≡⟨ ≡sym (cast-sucF {suc (toℕ i + suc n)} {toℕ i + suc (suc n)} {≡sym (+-suc (toℕ i) (suc n))} {≡sym (+-suc (suc (toℕ i)) (suc n))} (sucF (i +F (sucF j)))) ⟩
+  cast (≡sym (+-suc (suc (toℕ i)) (suc n))) (sucF (sucF (i +F (sucF j))))
+  ∎
 
 inject≤inject₁≡inject₁inject≤ : ∀ {m n} {i : Fin m} → (m≤n : m ≤ n)
   → inject≤ (inject₁ i) (s≤s m≤n) ≡ inject₁ (inject≤ i m≤n)
@@ -61,18 +111,6 @@ inject≤inject₁≡inject₁inject≤ {.(suc _)} {.(suc _)} {sucF i} (s≤s m�
   sucF (inject≤ (inject₁ i) (s≤s m≤n))
   ≡⟨ ≡cong sucF (inject≤inject₁≡inject₁inject≤ m≤n) ⟩
   sucF (inject₁ (inject≤ i m≤n))
-  ∎
-
-inject≤[inject≤[i][k≤m]][m≤n]≡inject≤[i][k≤n] : {k m n : ℕ}
-  → (i : Fin k)
-  → (k≤m : k ≤ m) → (m≤n : m ≤ n) → (k≤n : k ≤ n)
-  → inject≤ (inject≤ i k≤m) m≤n ≡ inject≤ i k≤n
-inject≤[inject≤[i][k≤m]][m≤n]≡inject≤[i][k≤n] {.(suc _)} {suc m} {suc n} zeroF k≤sm sm≤sn k≤sn = ≡refl
-inject≤[inject≤[i][k≤m]][m≤n]≡inject≤[i][k≤n] {.(suc _)} {suc m} {suc n} (sucF i) k≤m m≤n k≤n =
-  begin
-  sucF (inject≤ (inject≤ i (≤-pred k≤m)) (≤-pred m≤n))
-  ≡⟨ ≡cong sucF (inject≤[inject≤[i][k≤m]][m≤n]≡inject≤[i][k≤n] i (≤-pred k≤m) (≤-pred m≤n) (≤-pred k≤n)) ⟩
-  sucF (inject≤ i (≤-pred k≤n))
   ∎
 
 inject≤[fromℕ<[a≤b]][b≤c]≡fromℕ<[a≤c] : {a b c : ℕ}
@@ -160,17 +198,13 @@ s[cast[fromℕ[a]+Fiᵇ]]≡cast[fromℕ[a]+Fsiᵇ]
   {suc a} {b} {.(toℕ (fromℕ (suc a)) + b)} {j} ≡refl q =
   ≡cong sucF (s[cast[fromℕ[a]+Fiᵇ]]≡cast[fromℕ[a]+Fsiᵇ] {a} {b} {_} {j} ≡refl (≡cong (λ i → i ∸ 1) q) )
 
-cast[fromℕ[a]]≡fromℕ[a] : ∀ {a : ℕ} → {p : suc a ≡ suc a} → cast p (fromℕ a) ≡ fromℕ a
-cast[fromℕ[a]]≡fromℕ[a] {zero} {≡refl} = ≡refl
-cast[fromℕ[a]]≡fromℕ[a] {suc a} {≡refl} = ≡cong sucF (cast[fromℕ[a]]≡fromℕ[a] {a} {≡refl})
-
 cast[fromℕ[sk']+Ffromℕ[l]]≡s[fromℕ[k'+l]] : ∀ {k' l : ℕ}
   → (p : toℕ (fromℕ (suc k')) + suc l ≡ suc (suc k' + l))
   → cast p (fromℕ (suc k') +F fromℕ l) ≡ sucF (fromℕ (k' + l))
 cast[fromℕ[sk']+Ffromℕ[l]]≡s[fromℕ[k'+l]] {zero} {zero} ≡refl = ≡refl
 cast[fromℕ[sk']+Ffromℕ[l]]≡s[fromℕ[k'+l]] {zero} {suc l} ≡refl =
   ≡cong (λ i → sucF (sucF i))
-    (cast[fromℕ[a]]≡fromℕ[a] {l} {≡refl})
+    (casti≡i {suc l} {≡refl} (fromℕ l))
 cast[fromℕ[sk']+Ffromℕ[l]]≡s[fromℕ[k'+l]] {suc k'} {l} p =
   ≡cong sucF (cast[fromℕ[sk']+Ffromℕ[l]]≡s[fromℕ[k'+l]] {k'} {l} (≡cong (λ i → i ∸ 1) p))
 

--- a/src/QSimulation/Lemma.agda
+++ b/src/QSimulation/Lemma.agda
@@ -25,10 +25,6 @@ a≡a+b→b≡0 : ∀ {a b : ℕ} → a ≡ a + b → b ≡ zero
 a≡a+b→b≡0 {zero} {.zero} ≡refl = ≡refl
 a≡a+b→b≡0 {suc a} {b} p = a≡a+b→b≡0 {a} {b} (≡cong (λ i → i ∸ 1) p)
 
-a≤b+a : {a b : ℕ} → a ≤ b + a
-a≤b+a {a} {zero} = ≤-refl
-a≤b+a {a} {suc b} = ≤-step a≤b+a
-
 ≡-pred : ∀ {n m : ℕ} → suc n ≡ suc m → n ≡ m
 ≡-pred ≡refl = ≡refl
 
@@ -57,6 +53,16 @@ toℕfromℕ≡id : ∀ (i : ℕ) → toℕ (fromℕ i) ≡ i
 toℕfromℕ≡id zero = ≡refl
 toℕfromℕ≡id (suc i) = ≡cong suc (toℕfromℕ≡id i)
 
+inject≤inject₁≡inject₁inject≤ : ∀ {m n} {i : Fin m} → (m≤n : m ≤ n)
+  → inject≤ (inject₁ i) (s≤s m≤n) ≡ inject₁ (inject≤ i m≤n)
+inject≤inject₁≡inject₁inject≤ {.(suc _)} {.(suc _)} {zeroF} (s≤s m≤n) = ≡refl
+inject≤inject₁≡inject₁inject≤ {.(suc _)} {.(suc _)} {sucF i} (s≤s m≤n) =
+  begin
+  sucF (inject≤ (inject₁ i) (s≤s m≤n))
+  ≡⟨ ≡cong sucF (inject≤inject₁≡inject₁inject≤ m≤n) ⟩
+  sucF (inject₁ (inject≤ i m≤n))
+  ∎
+
 inject≤[fromℕ[sa]][sa<sb]≡s[fromℕ<[a<b]] : {a b : ℕ}
   → (ssa≤sb : suc (suc a) ≤ suc b)
   → (sa≤b : suc a ≤ b)
@@ -65,14 +71,14 @@ inject≤[fromℕ[sa]][sa<sb]≡s[fromℕ<[a<b]] {zero} {suc b} p q = ≡refl
 inject≤[fromℕ[sa]][sa<sb]≡s[fromℕ<[a<b]] {suc a} {.(suc _)} (s≤s p) (s≤s q)
   = ≡cong sucF (inject≤[fromℕ[sa]][sa<sb]≡s[fromℕ<[a<b]] {a} p q)
 
-[sk]+iˡ≡k+siˡ : ∀ {k l n : ℕ} → {i : Fin l}
+[sk]+iˡ≡k+siˡ : ∀ {k l : ℕ} → {i : Fin l}
   → {p : suc k + suc l ≡ suc (toℕ (fromℕ k)) + suc l}
   → cast p (inject+' (suc k) (inject₁ i)) ≡ inject₁ (cast ≡refl (fromℕ k +F sucF i))
-[sk]+iˡ≡k+siˡ {zero} {l} {n} {zeroF} {≡refl} = ≡refl
-[sk]+iˡ≡k+siˡ {zero} {suc l} {n} {sucF i} {≡refl} =
-  ≡cong sucF ([sk]+iˡ≡k+siˡ {zero} {l} {n} {i} {≡refl})
-[sk]+iˡ≡k+siˡ {suc k} {l} {n} {i} {p} =
-  ≡cong sucF ([sk]+iˡ≡k+siˡ {k} {l} {n} {i} {≡cong (λ i → i ∸ 1) p})
+[sk]+iˡ≡k+siˡ {zero} {l} {zeroF} {≡refl} = ≡refl
+[sk]+iˡ≡k+siˡ {zero} {suc l} {sucF i} {≡refl} =
+  ≡cong sucF ([sk]+iˡ≡k+siˡ {zero} {l} {i} {≡refl})
+[sk]+iˡ≡k+siˡ {suc k} {l} {i} {p} =
+  ≡cong sucF ([sk]+iˡ≡k+siˡ {k} {l} {i} {≡cong (λ i → i ∸ 1) p})
 
 s[k+iˡ]≡k+siˡ : ∀ {k l n : ℕ} → {i : Fin l}
   → (p : toℕ (fromℕ k) + suc l ≡ suc n)
@@ -84,13 +90,13 @@ s[k+iˡ]≡k+siˡ {zero} {suc l} {.(suc l)} {sucF i} ≡refl ≡refl =
 s[k+iˡ]≡k+siˡ {suc k} {sl@.(suc _)} {.(toℕ (fromℕ k) + suc (suc _))} {zeroF} p@≡refl q =
   begin
   sucF (cast q (inject+' (suc k) (inject₁ zeroF)))
-  ≡⟨ ≡cong sucF ([sk]+iˡ≡k+siˡ {k} {sl} {toℕ (fromℕ k) + suc sl} {zeroF} {q}) ⟩
+  ≡⟨ ≡cong sucF ([sk]+iˡ≡k+siˡ {k} {sl} {zeroF} {q}) ⟩
   sucF (inject₁ (cast ≡refl (fromℕ k +F sucF zeroF)))
   ≡⟨⟩
   inject₁ (cast ≡refl (fromℕ (suc k) +F sucF zeroF))
   ∎
 s[k+iˡ]≡k+siˡ {suc k} {sl@.(suc _)} {.(toℕ (fromℕ k) + suc (suc _))} {sucF i} ≡refl q =
-  ≡cong sucF ([sk]+iˡ≡k+siˡ {k} {sl} {toℕ (fromℕ k) + suc sl} {sucF i} {q})
+  ≡cong sucF ([sk]+iˡ≡k+siˡ {k} {sl} {sucF i} {q})
 
 [inject+]≡[+F] : ∀ {k l n : ℕ}
   → (i : Fin l)

--- a/src/QSimulation/Lemma.agda
+++ b/src/QSimulation/Lemma.agda
@@ -6,6 +6,8 @@ open import Data.Nat.Properties
 open import Data.Fin
   using (Fin; inject₁; inject≤; fromℕ; fromℕ<; toℕ; cast)
   renaming (zero to zeroF; suc to sucF; _+_ to _+F_)
+open import Data.Fin.Properties
+  using (toℕ-fromℕ)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; _≢_; inspect; [_])
   renaming (refl to ≡refl; sym to ≡sym; cong to ≡cong)
@@ -47,6 +49,10 @@ ss[k'+l']≡ss[k'+l]→l'≡l {zero} {l'} {.l'} ≡refl = ≡refl
 ss[k'+l']≡ss[k'+l]→l'≡l {suc k'} {l'} {l} p =
   ss[k'+l']≡ss[k'+l]→l'≡l {k'} {l'} {l} (≡cong (λ i → i ∸ 1) p)
 
+s≤s-≤ : ∀ {n m : ℕ} → (n≤m : n ≤ m) (sn≤sm : suc n ≤ suc m) → (s≤s n≤m) ≡ sn≤sm
+s≤s-≤ {zero} {zero} z≤n (s≤s z≤n) = ≡refl
+s≤s-≤ {zero} {suc m} z≤n (s≤s z≤n) = ≡refl
+s≤s-≤ {suc n} {.(suc _)} (s≤s n≤m) (s≤s sn≤sm) = ≡cong s≤s (s≤s-≤ n≤m sn≤sm)
 
 -- conversion of index of type `Fin m`
 casti≡i : ∀ {n : ℕ} → {p : n ≡ n} → (i : Fin n) → cast p i ≡ i
@@ -122,6 +128,26 @@ fromℕ-+F-+ (suc m) n {p} = begin
   sucF (fromℕ (m + n))
   ∎
 
+fromℕ-+F-+-cast : (l m n : ℕ)
+  → {p : toℕ (fromℕ m) + suc n ≡ l}
+  → {q : suc (m + n) ≡ l}
+  → (cast p (fromℕ m +F fromℕ n)) ≡ (cast q (fromℕ (m + n)))
+fromℕ-+F-+-cast .(suc (m + n)) m n {p} {≡refl} =
+  begin
+  (cast p (fromℕ m +F fromℕ n))
+  ≡⟨ fromℕ-+F-+ m n {p} ⟩
+  fromℕ (m + n)
+  ≡⟨ ≡sym (casti≡i {suc (m + n)} {≡refl} (fromℕ (m + n))) ⟩
+  cast ≡refl (fromℕ (m + n))
+  ∎
+
+cast-fromℕ : (l m n : ℕ)
+  → (p : suc m ≡ l) → (q : suc n ≡ l)
+  → (r : m ≡ n)
+  → cast p (fromℕ m) ≡ cast q (fromℕ n)
+cast-fromℕ .(suc m) m .m ≡refl ≡refl ≡refl = ≡refl
+
+
 inject≤inject₁≡inject₁inject≤ : ∀ {m n} {i : Fin m} → (m≤n : m ≤ n)
   → inject≤ (inject₁ i) (s≤s m≤n) ≡ inject₁ (inject≤ i m≤n)
 inject≤inject₁≡inject₁inject≤ {.(suc _)} {.(suc _)} {zeroF} (s≤s m≤n) = ≡refl
@@ -130,6 +156,50 @@ inject≤inject₁≡inject₁inject≤ {.(suc _)} {.(suc _)} {sucF i} (s≤s m�
   sucF (inject≤ (inject₁ i) (s≤s m≤n))
   ≡⟨ ≡cong sucF (inject≤inject₁≡inject₁inject≤ m≤n) ⟩
   sucF (inject₁ (inject≤ i m≤n))
+  ∎
+
+inject≤[fromℕ<[sa≤b][b≤c]]≡inject≤[fromℕ[a]][sa≤c] : {a b c : ℕ}
+  → (sa≤b : suc a ≤ b)
+  → (b≤c : b ≤ c)
+  → (sa≤c : suc a ≤ c)
+  → inject≤ (fromℕ< sa≤b) (b≤c) ≡ inject≤ (fromℕ a) sa≤c
+inject≤[fromℕ<[sa≤b][b≤c]]≡inject≤[fromℕ[a]][sa≤c] {zero} {.(suc _)} {.(suc _)} (s≤s sa≤b) (s≤s b≤c) (s≤s sa≤c) = ≡refl
+inject≤[fromℕ<[sa≤b][b≤c]]≡inject≤[fromℕ[a]][sa≤c] {suc a} {.(suc _)} {.(suc _)} (s≤s sa≤b) (s≤s b≤c) (s≤s sa≤c) =
+  begin
+  sucF (inject≤ (fromℕ< sa≤b) b≤c)
+  ≡⟨ ≡cong sucF (inject≤[fromℕ<[sa≤b][b≤c]]≡inject≤[fromℕ[a]][sa≤c] sa≤b b≤c sa≤c) ⟩
+  sucF (inject≤ (fromℕ a) sa≤c)
+  ∎
+
++F-inject₁ : {b c : ℕ}
+  → (a : Fin b)
+  → (i : Fin c)
+  → (p : toℕ a + suc c ≡ suc (toℕ a + c))
+  → cast p (a +F inject₁ i) ≡ inject₁ (a +F i)
++F-inject₁ {.(suc _)} {.(suc _)} zeroF zeroF p = ≡refl
++F-inject₁ {.(suc _)} {.(suc _)} zeroF (sucF i) p = begin
+  sucF (cast (≡cong (λ z → z ∸ 1) p) (inject₁ i))
+  ≡⟨ ≡cong sucF (casti≡i {_} {≡refl} (inject₁ i)) ⟩
+  sucF (inject₁ i)
+  ∎
++F-inject₁ {.(suc _)} {c} (sucF a) i p = begin
+  sucF (cast (≡cong (λ z → z ∸ 1) p) (a +F inject₁ i))
+  ≡⟨ ≡cong sucF (+F-inject₁ a i (≡cong (λ z → z ∸ 1) p)) ⟩
+  sucF (inject₁ (a +F i))
+  ∎
+
+cast-fromℕ-+F-inject₁ : {b c d : ℕ}
+  → (a : Fin d)
+  → (i : Fin b)
+  → (p : toℕ a + suc b ≡ suc c)
+  → (q : toℕ a + b ≡ c)
+  → cast p (a +F inject₁ i) ≡ inject₁ (cast q (a +F i))
+cast-fromℕ-+F-inject₁ {b} {.(toℕ a + b)} a i p ≡refl = begin
+  cast p (a +F inject₁ i)
+  ≡⟨ +F-inject₁ a i p ⟩
+  inject₁ (a +F i)
+  ≡⟨ ≡cong inject₁ (≡sym (casti≡i {_} {≡refl} (a +F i))) ⟩
+  inject₁ (cast ≡refl (a +F i))
   ∎
 
 inject≤[fromℕ<[a≤b]][b≤c]≡fromℕ<[a≤c] : {a b c : ℕ}
@@ -188,6 +258,47 @@ s[k+iˡ]≡k+siˡ {suc k} {sl@.(suc _)} {.(toℕ (fromℕ k) + suc (suc _))} {su
 [inject+]≡[+F] {zero} {.n} {n} i ≡refl ≡refl = ≡refl
 [inject+]≡[+F] {suc k} {suc l} {.(suc k + suc l)} i ≡refl q =
   ≡cong sucF ([inject+]≡[+F] {k} i ≡refl (≡cong (λ j → j ∸ 1) q))
+
+cast-inject+'-fromℕ : ∀ (a b : ℕ)
+    → (i : Fin a)
+    → (q : toℕ (fromℕ b) + suc a ≡ suc (b + a))
+    → inject+' (suc b) i ≡ cast q (fromℕ b +F sucF i)
+cast-inject+'-fromℕ (suc a) b i q = begin
+    inject+' (suc b) i
+    ≡⟨⟩
+    sucF (inject+' b i)
+    ≡⟨ ≡cong sucF (≡sym (casti≡i {b + suc a} {≡refl} (inject+' b i))) ⟩
+    sucF (cast ≡refl (inject+' b i))
+    ≡⟨ ≡cong sucF ([inject+]≡[+F] {b} i ≡refl p₂) ⟩
+    sucF (cast p₂ (fromℕ b +F i))
+    ≡⟨ cast-sucF {toℕ (fromℕ b) + suc a} {b + suc a} {p₂} {p₃} (fromℕ b +F i) ⟩
+    cast p₃ (sucF (fromℕ b +F i))
+    ≡⟨ ≡sym (cast-cast p₁ q p₃  (sucF (fromℕ b +F i))) ⟩
+    cast q (cast p₁ (sucF (fromℕ b +F i)))
+    ≡⟨ ≡cong (λ i → cast q i) (≡sym (+F-sucF (fromℕ b) i)) ⟩
+    cast q (fromℕ b +F sucF i)
+    ∎
+    where
+        p₁ : suc (toℕ (fromℕ b) + suc a) ≡ toℕ (fromℕ b) + suc (suc a)
+        p₁ = ≡sym (+-suc (toℕ (fromℕ b)) (suc a))
+        p₂ : toℕ (fromℕ b) + suc a ≡ b + suc a
+        p₂ = ≡cong (λ i → (i + suc a)) (toℕ-fromℕ b)
+        p₃ : suc (toℕ (fromℕ b) + suc a) ≡ suc (b + suc a)
+        p₃ = ≡cong suc p₂
+                    
+cast-inject+'-cast-fromℕ : ∀ (a b c : ℕ)
+    → (i : Fin a)
+    → (p : suc (b + a) ≡ c)
+    → (q : toℕ (fromℕ b) + suc a ≡ c)
+    → cast p (inject+' (suc b) i) ≡ cast q (fromℕ b +F sucF i)
+cast-inject+'-cast-fromℕ a b .(suc (b + a)) i ≡refl q = begin
+    cast ≡refl (inject+' (suc b) i)
+    ≡⟨ casti≡i {suc (b + a)} {≡refl} (sucF (inject+' b i)) ⟩
+    inject+' (suc b) i
+    ≡⟨ cast-inject+'-fromℕ a b i q ⟩
+    cast q (fromℕ b +F sucF i)
+    ∎
+
 
 inject≤[fromℕ[a]][a<b]≡cast[fromℕ[a]+F0] : ∀ {a b c : ℕ}
   → (sa≤b : suc a ≤ b)
@@ -339,4 +450,5 @@ module Transition
       ≡⟨ ≡cong (λ a → y·y' (inject₁ i) , concat w w' i , a) y'[sj']≡tail[y]·y'[i] ⟩
       y·y' (inject₁ i) , concat w w' i , concat (tailF y) (tailF y') i
       ∎)
+ 
  

--- a/src/QSimulation/Lemma.agda
+++ b/src/QSimulation/Lemma.agda
@@ -37,6 +37,13 @@ k≢0→k<sn→sk'≡k : ∀ {k n : ℕ}
 k≢0→k<sn→sk'≡k {zero} {n} p (s≤s q) = contradiction ≡refl p
 k≢0→k<sn→sk'≡k {suc k} {n} p q = (k , ≡refl)
 
+k≤n⊎n<k : (k n : ℕ) → (k ≤ n) ⊎ (n < k)
+k≤n⊎n<k zero n = inj₁ z≤n
+k≤n⊎n<k (suc k) zero = inj₂ (s≤s z≤n)
+k≤n⊎n<k (suc k) (suc n) with k≤n⊎n<k k n
+k≤n⊎n<k (suc k) (suc n) | inj₁ k≤n = inj₁ (s≤s k≤n)
+k≤n⊎n<k (suc k) (suc n) | inj₂ n<k = inj₂ (s≤s n<k)
+
 s[k+l']≡ss[k+l]→l'≡sl : ∀ {k l l' : ℕ}
   → suc (k + l') ≡ suc (suc (k + l)) → l' ≡ suc l
 s[k+l']≡ss[k+l]→l'≡sl {zero} {l} {.(suc l)} ≡refl = ≡refl
@@ -299,6 +306,12 @@ cast-inject+'-cast-fromℕ a b .(suc (b + a)) i ≡refl q = begin
     cast q (fromℕ b +F sucF i)
     ∎
 
+inject≤[i][n≤n]≡i : {n : ℕ}
+  → (i : Fin n)
+  → (n≤n : n ≤ n)
+  → inject≤ i n≤n ≡ i
+inject≤[i][n≤n]≡i {.(suc _)} zeroF n≤n = ≡refl
+inject≤[i][n≤n]≡i {.(suc _)} (sucF i) n≤n = ≡cong sucF (inject≤[i][n≤n]≡i i (≤-pred n≤n))
 
 inject≤[fromℕ[a]][a<b]≡cast[fromℕ[a]+F0] : ∀ {a b c : ℕ}
   → (sa≤b : suc a ≤ b)

--- a/src/QSimulation/Properties.agda
+++ b/src/QSimulation/Properties.agda
@@ -18,9 +18,12 @@ Monotonicity-≤ : {A X X' : Set} {na : NA X A} {na' : NA X' A} →
 Monotonicity-≤ Q Q' Q⊆Q' (x , y) x≤[Q]y w w∈L*[x] with x≤[Q]y w w∈L*[x]
 ... | (w' , w'∈L*[y] , [w,w']∈Q) = (w' ,  w'∈L*[y] , Q⊆Q' [w,w']∈Q)
 
+-- properties of M-bounded Q-constrained simulation
+open import QSimulation.Bounded public
+
 -- soundness
 open import QSimulation.Soundness public
-  using (soundness)
+  using (soundness; soundness-of-bounded-simulation)
 
 -- soundness of up-to version
 open import QSimulation.SoundnessUpto public

--- a/src/QSimulation/Soundness.agda
+++ b/src/QSimulation/Soundness.agda
@@ -28,6 +28,8 @@ open import QSimulation.Base
 open QSimulation.Base.ConditionOnQ A
 open QSimulation.Base.QSimulationBase A X₁ X₂ na₁ na₂
 open import QSimulation.Lemma
+open import QSimulation.Bounded A X₁ X₂ na₁ na₂
+  using (Mbounded⇒unbounded)
 
 module Soundness
   (Q@(aPreorder ∣Q∣ Qrefl Qtrans) : Preorder)
@@ -312,6 +314,8 @@ module Soundness
           -- proof of y ⇝[w'·w''] y'
           open QSimulation.Lemma.Transition X₂ A na₂ m m' ys ys' ys'0≡ys[m] w' w'' trw' trw''
           trw'w'' : (i : Fin (m + m')) → NA.trans na₂ (ys·ys' (inject₁ i) , concat w' w'' i , ys·ys' (sucF i))
+          trw'w'' i = tr i
+          {-
           trw'w'' i with lemma-for-trans-state {m} {m'} ys ys' ys'0≡ys[m] i | lemma-for-trans-word {m} {m'} w' w'' i
           trw'w'' i | p | q with splitFin {m} {m'} i
           trw'w'' i | ys[i']≡ys·ys'[i] , ys[si']≡tail[ys]·ys'[i] | q | inj₁ i' =
@@ -336,7 +340,8 @@ module Soundness
               ≡⟨ ≡cong (λ a → (concat ys (tailF ys') (inject₁ i) , a , concat (tailF ys) (tailF ys') i)) q ⟩
               concat ys (tailF ys') (inject₁ i) , concat w' w'' i , concat (tailF ys) (tailF ys') i
               ∎)
-  
+          -}
+
           last[ys·ys']∈F₂ : NA.accept na₂ (ys·ys' (fromℕ (m + m')))
           last[ys·ys']∈F₂ = step-∋ (NA.accept na₂) last[ys']∈F₂ (last-concat {X₂} ys ys' ys'0≡ys[m])
   
@@ -419,3 +424,15 @@ module Soundness
         R₁ [R₁]⊆[≤[≡]] R₂ [R₂]⊆[≤[≡]] R-as-[Q,R₁,R₂]-sim [x,y] [x,y]∈R
 open Soundness using (soundness) public
 
+soundness-of-bounded-simulation :
+  (M : ℕ)
+  → (0<M : zero < M)
+  → (Q : Preorder)
+  → (Q-is-closed-under-concat : [ Q ]-is-closed-under-concat)
+  → (Mbounded-Qconstrained-simulation@(aBoundedConstrainedSimulation R FinalM StepM) : [ M ]-bounded-[ Q ]-constrained-simulation)
+  → ((x , y) : X₁ × X₂) → (x , y) ∈ R → x ≤[ na₁ , na₂ , Q ] y
+soundness-of-bounded-simulation M 0<M Q Q-is-closed-under-concat Mbounded-Qconstrained-simulation@(aBoundedConstrainedSimulation R FinalM StepM) (x , y) [x,y]∈R =
+  soundness Q Q-is-closed-under-concat unbounded-Qconstrained-simulation (x , y) [x,y]∈R
+  where
+    unbounded-Qconstrained-simulation : [ Q ]-constrained-simulation
+    unbounded-Qconstrained-simulation = Mbounded⇒unbounded M 0<M Q Q-is-closed-under-concat Mbounded-Qconstrained-simulation

--- a/src/QSimulation/Soundness.agda
+++ b/src/QSimulation/Soundness.agda
@@ -338,20 +338,7 @@ module Soundness
               ∎)
   
           last[ys·ys']∈F₂ : NA.accept na₂ (ys·ys' (fromℕ (m + m')))
-          last[ys·ys']∈F₂ = step-∋ (NA.accept na₂) last[ys']∈F₂ (last ys ys' ys'0≡ys[m])
-            where
-              last : {s t : ℕ} → (a : Fin (suc s) → X₂) → (b : Fin (suc t) → X₂)
-                → (b0≡last[a] : b zeroF ≡ a (fromℕ s))
-                → b (fromℕ t) ≡ concat a (tailF b) (fromℕ (s + t))
-              last {zero} {zero} a b b0≡last[a] = b0≡last[a]
-              last {zero} {suc t} a b b0≡last[a] = ≡refl
-              last {suc s} {t} a b b0≡last[a] = begin
-                b (fromℕ t)
-                ≡⟨ last {s} {t} (tailF a) b b0≡last[a] ⟩
-                concat (tailF a) (tailF b) (fromℕ (s + t))
-                ≡⟨⟩
-                concat a (tailF b) (fromℕ (suc s + t))
-                ∎
+          last[ys·ys']∈F₂ = step-∋ (NA.accept na₂) last[ys']∈F₂ (last-concat {X₂} ys ys' ys'0≡ys[m])
   
           -- proof of (w , w'·w'') ∈ Q
           -- use concat-closedness of Q

--- a/src/QSimulation/Soundness.agda
+++ b/src/QSimulation/Soundness.agda
@@ -10,6 +10,8 @@ open import Data.Nat.Induction using (<-rec)
 open import Data.Fin
   using (Fin; inject₁; inject≤; fromℕ; fromℕ<; toℕ; cast)
   renaming (zero to zeroF; suc to sucF; _+_ to _+F_)
+open import Data.Fin.Properties
+  using (toℕ-fromℕ)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; _≢_; inspect; [_])
   renaming (refl to ≡refl; sym to ≡sym; cong to ≡cong)
@@ -48,7 +50,7 @@ module Soundness
     → (inj l w ∈ FINAccLang na₁ x)
     → ∃[ w' ] -- : FINWord A
       (w' ∈ FINAccLang na₂ y) × (Preorder.carrier Q (inj l w , w'))
-  -- proof by infuction on length of word w such as x⇝[w]x'
+  -- proof by induction on length of word w such as x⇝[w]x'
   -- Base case
   lemma-for-soundness zero _ (.(headF xs) , y) [x,y]∈R w w∈L*[x]@(xs , ≡refl , trw , last[xs]∈F₁) with Rfinal (headF xs) y [x,y]∈R last[xs]∈F₁ | 0-length-word≡ε w
   lemma-for-soundness zero rec (.(headF xs) , y) [x,y]∈R w w∈L*[x]@(xs , ≡refl , trw , last[xs]∈F₁) | w'@(n , as) , y' , y⇝[w']y'@(ys , ≡refl , tr₂ , ≡refl) , y'∈F₂ , ε∣Q∣w' | ≡refl  =
@@ -169,10 +171,10 @@ module Soundness
           )
   
       toℕfromℕk+l≡sn : toℕ (fromℕ k) + l ≡ suc n
-      toℕfromℕk+l≡sn = (≡cong (λ i → i + l) (toℕfromℕ≡id k))
+      toℕfromℕk+l≡sn = (≡cong (λ i → i + l) (toℕ-fromℕ k))
   
       toℕfromℕk+sl≡ssn : toℕ (fromℕ k) + suc l ≡ suc (suc n)
-      toℕfromℕk+sl≡ssn with toℕfromℕ≡id k
+      toℕfromℕk+sl≡ssn with toℕ-fromℕ k
       toℕfromℕk+sl≡ssn | p = begin
         toℕ (fromℕ k) + suc l
         ≡⟨ ≡cong (λ i → i + suc l) p ⟩
@@ -221,7 +223,7 @@ module Soundness
         ∎
   
       trw₂ : ∀ (i : Fin l) → NA.trans na₁ (xs₂ (inject₁ i) , w₂ i , xs₂ (sucF i))
-      trw₂ i with toℕfromℕ≡id k
+      trw₂ i with toℕ-fromℕ k
       trw₂ i | p = step-∋ (NA.trans na₁) trw[k+i]
         (≡sym (begin
         xs₂ (inject₁ i) ,  w₂ i , xs₂^ i          

--- a/src/QSimulation/SoundnessUpto.agda
+++ b/src/QSimulation/SoundnessUpto.agda
@@ -6,7 +6,7 @@ module QSimulation.SoundnessUpto
   where
 
 open import Data.Nat
-open import Data.Nat.Properties
+open import Data.Nat.Properties using(+-suc; ≤-trans; m≤n+m)
 open import Data.Nat.Induction using (<-rec)
 open import Data.Fin
   using (Fin; inject₁; inject≤; fromℕ; fromℕ<; toℕ; cast)
@@ -327,7 +327,7 @@ module Soundness
         y^ ⇝[v^] y♯ ∈ F₂
       -}
       n^≤k'+l : n^ ≤ k' + l
-      n^≤k'+l = ≤-trans n^≤l (a≤b+a {l} {k'})
+      n^≤k'+l = ≤-trans n^≤l (m≤n+m l k')
 
       [m^,v^,v^∈L[y^],[w^,v^]∈Q] : ∃[ m^ ] ∃ λ (v^ : FinWord m^ A)
         → (inj m^ v^ ∈ FINAccLang na₂ y^) × ((inj n^ w^ , inj m^ v^) ∈ ∣Q∣)
@@ -493,3 +493,4 @@ module Soundness
       soundness' l  = <-rec (λ l → _) lemma-for-soundness l
 
 open Soundness using (soundness) public
+ 

--- a/src/QSimulation/SoundnessUpto.agda
+++ b/src/QSimulation/SoundnessUpto.agda
@@ -11,6 +11,8 @@ open import Data.Nat.Induction using (<-rec)
 open import Data.Fin
   using (Fin; inject₁; inject≤; fromℕ; fromℕ<; toℕ; cast)
   renaming (zero to zeroF; suc to sucF; _+_ to _+F_)
+open import Data.Fin.Properties
+  using (toℕ-fromℕ)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; _≢_; inspect; [_])
   renaming (refl to ≡refl; sym to ≡sym; cong to ≡cong)
@@ -174,10 +176,10 @@ module Soundness
         ∎
 
       toℕfromℕk+l≡sn : toℕ (fromℕ k) + l ≡ suc n
-      toℕfromℕk+l≡sn = (≡cong (λ i → i + l) (toℕfromℕ≡id k))
+      toℕfromℕk+l≡sn = (≡cong (λ i → i + l) (toℕ-fromℕ k))
   
       toℕfromℕk+sl≡ssn : toℕ (fromℕ k) + suc l ≡ suc (suc n)
-      toℕfromℕk+sl≡ssn with toℕfromℕ≡id k
+      toℕfromℕk+sl≡ssn with toℕ-fromℕ k
       toℕfromℕk+sl≡ssn | p = begin
         toℕ (fromℕ k) + suc l
         ≡⟨ ≡cong (λ i → i + suc l) p ⟩
@@ -226,7 +228,7 @@ module Soundness
         ∎
 
       trw₂ : ∀ (i : Fin l) → (xs₂ (inject₁ i) , w₂ i , xs₂ (sucF i)) ∈ ⇝₁
-      trw₂ i with toℕfromℕ≡id k
+      trw₂ i with toℕ-fromℕ k
       trw₂ i | p = step-∋ ⇝₁ trw[k+i]
         (≡sym (begin
         xs₂ (inject₁ i) ,  w₂ i , xs₂^ i          

--- a/src/Word/Base.agda
+++ b/src/Word/Base.agda
@@ -3,7 +3,7 @@ open import Level
   using (Level)
   renaming (zero to lzero; suc to lsuc)
 open import Data.Nat
-  using (ℕ; zero; suc; _+_; _≤_; z≤n; s≤s)
+  using (ℕ; zero; suc; _+_; _≤_; _<_; z≤n; s≤s)
 open import Data.Fin
   using (Fin; inject₁; inject≤; inject+; cast; toℕ; fromℕ; fromℕ<)
   renaming (zero to 0F; suc to sucF)
@@ -104,6 +104,10 @@ split {A} {.(k + l)} {k} w k≤n | l , p@refl = (w₁ , w₂)
     w₁ i = w (inject≤ i k≤n)
     w₂ : FinWord l A
     w₂ j = w (cast p (inject+' k j))
+
+-- get the prefix of length k
+_↾_ : {A : Set} {n k : ℕ} → FinWord n A → k < suc n → FinWord k A
+w ↾ (s≤s k≤n) = proj₁ (split w k≤n)
 
 -- length
 ∣_∣ : {A : Set} → FINWord A → ℕ

--- a/src/Word/Properties.agda
+++ b/src/Word/Properties.agda
@@ -185,6 +185,23 @@ l≡k∧k≤l→[i↦w[inj[i][k≤l]]]≡[l≡k⋆w] {A} {k} {.k} {refl} {k≤k}
   w
   ∎
 
+inj[m][w]≡inj[n][λi→w[cast[i]]] : {A : Set}
+  → (m n : ℕ)
+  → (w : FinWord m A)
+  → (p : n ≡ m)
+  → inj m w ≡ inj n (λ i → w (cast p i))
+inj[m][w]≡inj[n][λi→w[cast[i]]] m .m w refl = begin
+  m , w
+  ≡⟨⟩
+  m , (λ i → w i)
+  ≡⟨ cong (λ a → m , a) (ex (λ i → cong w (i≡casti refl i))) ⟩
+  m , (λ i → w (cast refl i))
+  ∎
+  where
+    i≡casti : ∀ {n : ℕ} → (p : n ≡ n) → (i : Fin n) → i ≡ cast p i
+    i≡casti {.(suc _)} refl 0F = refl
+    i≡casti {.(suc _)} refl (sucF i) = cong sucF (i≡casti refl i)
+
 -- inj n (λ i → w (inject≤ i k≤n+0))   ≡   inj (n + 0) w
 -- This proposition is used in the proof of soundness of Q-simulation
 Prop[inj[n]w[inj≤i]≡inj[n+0]w] : {A : Set} → {k n : ℕ}
@@ -206,3 +223,18 @@ inj[n]w[inj≤i]≡inj[n+0]w {A} {k} {.k} w refl k≤n+0 = begin
   ≡⟨ sym (path-lifting-property w a+0≡a ) ⟩
   inj (k + zero) w
   ∎
+
+
+last-concat : {X : Set} → {s t : ℕ} → (a : Fin (suc s) → X) → (b : Fin (suc t) → X)
+  → (b0≡last[a] : b 0F ≡ a (fromℕ s))
+  → b (fromℕ t) ≡ concat a (tailF b) (fromℕ (s + t))
+last-concat {X₂} {zero} {zero} a b b0≡last[a] = b0≡last[a]
+last-concat {X₂} {zero} {suc t} a b b0≡last[a] = refl
+last-concat {X₂} {suc s} {t} a b b0≡last[a] = begin
+  b (fromℕ t)
+  ≡⟨ last-concat {X₂} {s} {t} (tailF a) b b0≡last[a] ⟩
+  concat (tailF a) (tailF b) (fromℕ (s + t))
+  ≡⟨⟩
+  concat a (tailF b) (fromℕ (suc s + t))
+  ∎
+  


### PR DESCRIPTION
- Definition of M-bounded Q-constrained simulation
- Proof of properties of M-bounded Q-constrained simulation
    - M≤N⇒FinalN⇒FinalM
    - M≤N⇒StepM⇒StepN
    - M≤N⇒StepM⇒FinalM⇒FinalN
    - M≤N⇒Mbounded⇒Nbounde
    - FinalM⇒Final
    - StepM⇒FinalM⇒Step
    - Mbounded⇒unbounded
    - soundness-of-bounded-simulation
 